### PR TITLE
Incremental refresh te3

### DIFF
--- a/te3/tutorials/incremental-refresh-about.md
+++ b/te3/tutorials/incremental-refresh-about.md
@@ -33,7 +33,7 @@ _Incremental refresh can be easily configured and modified from within Tabular E
 
 ### How does it work?
 
-To create the partitions, Power BI uses the `RangeStart` and `RangeEnd` _datetime_ parameters in Power Query. These parameters are used in a filter step of the table partition M Expression, filtering a table datetime column. Columns that are of date, string or integer types can still be filtered while maintaining query folding using functions that convert `RangeStart` or `RangeEnd` to datetime. For more information about this, see [here](https://learn.microsoft.com/en-us/power-bi/connect-data/incremental-refresh-overview#supported-data-sources)
+To create the partitions, Power BI uses the `RangeStart` and `RangeEnd` _datetime_ parameters in Power Query. These parameters are used in a filter step of the table partition M Expression, filtering a table datetime column. Columns that are of date, string or integer types can still be filtered while maintaining query folding using functions that convert `RangeStart` or `RangeEnd` to the appropriate data type. For more information about this, see [here](https://learn.microsoft.com/en-us/power-bi/connect-data/incremental-refresh-overview#supported-data-sources)
 
 An example is given below. Incremental Refresh is applied to a table _'Orders'_ upon the _[Order Date]_ column:
 

--- a/te3/tutorials/incremental-refresh-about.md
+++ b/te3/tutorials/incremental-refresh-about.md
@@ -33,7 +33,7 @@ _Incremental refresh can be easily configured and modified from within Tabular E
 
 ### How does it work?
 
-To create the partitions, Power BI uses the `RangeStart` and `RangeEnd` _datetime_ parameters in Power Query. These parameters are used in a filter step of the table partition M Expression, filtering a table date column. 
+To create the partitions, Power BI uses the `RangeStart` and `RangeEnd` _datetime_ parameters in Power Query. These parameters are used in a filter step of the table partition M Expression, filtering a table datetime column. Columns that are of date, string or integer types can still be filtered while maintaining query folding using functions that convert `RangeStart` or `RangeEnd` to datetime. For more information about this, see [here](https://learn.microsoft.com/en-us/power-bi/connect-data/incremental-refresh-overview#supported-data-sources)
 
 An example is given below. Incremental Refresh is applied to a table _'Orders'_ upon the _[Order Date]_ column:
 
@@ -47,8 +47,8 @@ An example is given below. Incremental Refresh is applied to a table _'Orders'_ 
     Table.SelectRows(
         Navigation,
         each 
-            [OrderDate] <= #"RangeStart" and 
-            [OrderDate] > #"RangeEnd"
+            [OrderDate] >= #"RangeStart" and 
+            [OrderDate] < #"RangeEnd"
     )
 ```
 
@@ -69,8 +69,8 @@ let
         Table.SelectRows(
             Navigation,
             each 
-                [OrderDate] <= #"RangeStart" and 
-                [OrderDate] > #"RangeEnd"
+                [OrderDate] >= #"RangeStart" and 
+                [OrderDate] < #"RangeEnd"
         )
 in
     #"Incremental Refresh Filter Step"
@@ -79,9 +79,8 @@ in
 # [RangeStart](#tab/rangestart)
 ```M
 // It does not matter what the initial value is for the RangeStart parameter
-// RangeStart should be greater than RangeEnd
 // The parameter must be of data type "datetime"
-#datetime(2022, 12, 31, 0, 0, 0) 
+#datetime(2022, 12, 01, 0, 0, 0) 
     meta 
         [
             IsParameterQuery = true, 
@@ -93,9 +92,8 @@ in
 # [RangeEnd](#tab/rangend)
 ```M
 // It does not matter what the initial value is for the RangeEnd parameter
-// RangeEnd should be less than RangeStart
 // The parameter must be of data type "datetime"
-#datetime(2022, 12, 01, 0, 0, 0) 
+#datetime(2022, 12, 31, 0, 0, 0) 
     meta 
         [
             IsParameterQuery = true, 

--- a/te3/tutorials/incremental-refresh-modify.md
+++ b/te3/tutorials/incremental-refresh-modify.md
@@ -66,7 +66,7 @@ Below is an overview of common changes one might make to an existing Refresh Pol
 
 __Purpose:__ Add or reduce the amount of data in the model.
 
-__Property:__ <span style="color:#BC4A47">_RollingWindowPeriods_</span>. Increase it to extend the window (more data); decrease it to reduce the window (less data).
+__Property:__ <span style="color:#BC4A47">_RollingWindowPeriods_</span>. Increase to extend the window (more data); decrease to reduce the window (less data).
 
 __Note:__ You can also change the <span style="color:#BC4A47">_RollingWindowGranularity_</span> to make a more fine-grain selection, i.e. from 3 Years to 36 Months.
 
@@ -80,7 +80,7 @@ __Note:__ You can also change the <span style="color:#BC4A47">_RollingWindowGran
 
 __Purpose:__ Add or reduce the amount of data being refreshed in a scheduled refresh operation.
 
-__Property:__ <span style="color:#455C86">_IncrementalWindowPeriods_</span>. Increase it to extend the window (more data); decrease it to reduce the window (less data).
+__Property:__ <span style="color:#455C86">_IncrementalWindowPeriods_</span>. Increase to extend the window (more data); decrease to reduce the window (less data).
 
 __Note:__ You can also change the <span style="color:#455C86">_IncrementalWindowGranularity_</span> to make a more fine-grain selection, i.e. from 3 Years to 36 Months.
 
@@ -112,10 +112,10 @@ __Property:__ _Mode_
 
 __Note:__ Follow the below process to change Incremental Refresh Mode:
 
-5. Change _Mode_ to the desired value `Import` or `Hybrid`
-6. Right-click the table and select _Apply Refresh Policy_
-7. Deploy the model changes
-8. Select and right-click all partitions and select _Refresh > Full refresh (partition)_
+1. Change _Mode_ to the desired value `Import` or `Hybrid`
+2. Right-click the table and select _Apply Refresh Policy_
+3. Deploy the model changes
+4. Select and right-click all partitions and select _Refresh > Full refresh (partition)_
 
 > [!NOTE]
 > It is recommended to check that the Rolling Window is appropriately set for the selected _Mode_. When switching from `Import` to `Hybrid` Mode, the latest Policy Range Partition will become the DirectQuery partition. You may wish to opt for a more fine-grain window, to limit the amount of data queried with DirectQuery.
@@ -134,8 +134,8 @@ __Property:__ _PollingExpression_. Add a valid M Expression which returns a maxi
 
 __Note:__ Follow the below process to configure 'Detect Data Changes':
 
-5. When the table is selected, in the _Expression Editor_ window, select _Polling Expression_ from the top-left dropdown
-6. Copy in the below M Expression, replacing _LastUpdate_ with your desired column name.
+1. When the table is selected, in the _Expression Editor_ window, select _Polling Expression_ from the top-left dropdown
+2. Copy in the below M Expression, replacing _LastUpdate_ with your desired column name.
 
 ```M
 // Retrieves the maximum value of the column [LastUpdate]
@@ -157,9 +157,9 @@ in
     accountForNu11
 ```
 
-7. Right-click the table and select _Apply Refresh Policy_
-8. Deploy the model changes
-9. Select and right-click all partitions and select _Refresh > Full refresh (partition)_
+3. Right-click the table and select _Apply Refresh Policy_
+4. Deploy the model changes
+5. Select and right-click all partitions and select _Refresh > Full refresh (partition)_
 
 > [!WARNING]
 > Any records will update if the value equals the maximum value in the column. It does not necessarily update explicitly  because the value has changed, or if the value equals the refresh date.
@@ -174,7 +174,7 @@ in
 
 If you want to generate partitions while overriding the current date (for purposes of generating different rolling window ranges), you can use a small script in Tabular Editor to apply the refresh policy with the [EffectiveDate](https://docs.microsoft.com/en-us/analysis-services/tmsl/refresh-command-tmsl?view=asallproducts-allversions#optional-parameters) parameter.
 
-With the incremental refresh table selected, run the following script in Tabular Editor's "Advanced Scripting" pane, in place of step 8 above:
+With the incremental refresh table selected, run the following script in Tabular Editor's _'New C# Script'_ pane instead of applying the refresh policy by right-clicking the table.
 
 ```csharp
 // Todo: replace with your effective date

--- a/te3/tutorials/incremental-refresh-setup.md
+++ b/te3/tutorials/incremental-refresh-setup.md
@@ -45,7 +45,25 @@ To set up Incremental Refresh, you must configure a new Refresh Policy for the t
       ]
   ```
 
-4. __Enable the Table Refresh Policy:__ Next, select the table for which you want to configure incremental refresh. Set the `EnableRefreshPolicy` property on the table to `True`:
+4. __Enable the Table Refresh Policy:__ Next, select the table for which you want to configure incremental refresh. In the _'Expression Editor' window, Select __'M Expression'__ from the dropdown, and alter the Power Query M Expression such that there is a filter step on the date column for which you will enable incremental refresh. 
+
+  _An example of one such valid filter step is below:_
+  
+  ```M
+  // The filter step must be able to fold back to the data source
+  // No steps before this should break query folding
+  #"Incremental Refresh Filter Step" = 
+      Table.SelectRows(
+          Navigation,
+          each 
+              [OrderDate] >= #"RangeStart" and 
+              [OrderDate] < #"RangeEnd"
+      )
+  ```
+
+  Columns that are of date, string or integer types can still be filtered while maintaining query folding using functions that convert `RangeStart` or `RangeEnd` to the appropriate data type. For more information about this, see [here](https://learn.microsoft.com/en-us/power-bi/connect-data/  incremental-refresh-overview#supported-data-sources)
+
+5. __Enable the Table Refresh Policy:__ In the _'Properties'_ window, set the `EnableRefreshPolicy` property on the table to `True`:
 
   <br></br>
 
@@ -53,7 +71,7 @@ To set up Incremental Refresh, you must configure a new Refresh Policy for the t
 
   <br></br>
 
-5. __Configure Refresh Policy:__ Configure the remaining properties according to the incremental refresh policy you need. Remember to specify an M expression for the `SourceExpression` property (this is the expression that will be added to partititions created by the incremental refresh policy, which should use the `RangeStart` and `RangeEnd` parameters to filter the data in the source). The = operator should only be applied to either RangeStart or RangeEnd, but not both, as data may be duplicated.
+6. __Configure Refresh Policy:__ Configure the remaining properties according to the incremental refresh policy you need. Remember to specify an M expression for the `SourceExpression` property (this is the expression that will be added to partititions created by the incremental refresh policy, which should use the `RangeStart` and `RangeEnd` parameters to filter the data in the source). The = operator should only be applied to either RangeStart or RangeEnd, but not both, as data may be duplicated.
 
     - __Source Expression:__ The M Expression that be added to partitions created by the Refresh Policy.
     - __IncrementalWindowGranularity:__ The granularity of the incremental (refresh) window.
@@ -70,8 +88,8 @@ To set up Incremental Refresh, you must configure a new Refresh Policy for the t
   
   <br></br>
 
-6. __Apply Model Changes:__ Save your model (Ctrl+S).
-7. __Apply Refresh Policy:__ Right-click on the table and choose "Apply Refresh Policy".
+7. __Apply Model Changes:__ Save your model (Ctrl+S).
+8. __Apply Refresh Policy:__ Right-click on the table and choose "Apply Refresh Policy".
 
   <br></br>
   
@@ -87,7 +105,7 @@ To set up Incremental Refresh, you must configure a new Refresh Policy for the t
   
   <br></br>
 
-8. __Refresh all partitions:__ Shift-click to select all partitions. Right-click and select _Refresh > Full refresh (partition)_.
+9. __Refresh all partitions:__ Shift-click to select all partitions. Right-click and select _Refresh > Full refresh (partition)_.
 
   <br></br>
 

--- a/te3/tutorials/incremental-refresh-setup.md
+++ b/te3/tutorials/incremental-refresh-setup.md
@@ -24,8 +24,8 @@ To set up Incremental Refresh, you must configure a new Refresh Policy for the t
 
 ## Set up from scratch with Tabular Editor
 
-1. Connect to the Power BI XMLA endpoint of your workspace, and open the dataset upon which you want to configure Incremental Refresh.
-2. Incremental refresh requires the `RangeStart` and `RangeEnd` parameters to be created ([more information](https://docs.microsoft.com/en-us/power-bi/connect-data/incremental-refresh-configure#create-parameters)). Add two new Shared Expressions in Tabular Editor:
+1. __Connect to the model:__ Connect to the Power BI XMLA endpoint of your workspace, and open the dataset upon which you want to configure Incremental Refresh.
+2. __Create the `RangeStart` and `RangeEnd` Parameters:__ Incremental refresh requires the `RangeStart` and `RangeEnd` parameters to be created ([more information](https://docs.microsoft.com/en-us/power-bi/connect-data/incremental-refresh-configure#create-parameters)). Add two new Shared Expressions in Tabular Editor:
 
   <br></br>
 
@@ -33,7 +33,7 @@ To set up Incremental Refresh, you must configure a new Refresh Policy for the t
 
   <br></br>
 
-3. Name them `RangeStart` and `RangeEnd` respectively, set their `Kind` property to "M" and set their expression to the following (the actual date/time value you specify doesn't matter, as it will be set by Power BI Service when starting the data refresh):
+3. __Configure the `RangeStart` and `RangeEnd` Parameters:__ Name them `RangeStart` and `RangeEnd` respectively, set their `Kind` property to "M" and set their expression to the following (the actual date/time value you specify doesn't matter, as it will be set by Power BI Service when starting the data refresh):
 
   ```M
   #datetime(2021, 6, 9, 0, 0, 0) 
@@ -45,8 +45,7 @@ To set up Incremental Refresh, you must configure a new Refresh Policy for the t
       ]
   ```
 
-4. Next, select the table for which you want to configure incremental refresh
-5. Set the `EnableRefreshPolicy` property on the table to `True`:
+4. __Enable the Table Refresh Policy:__ Next, select the table for which you want to configure incremental refresh. Set the `EnableRefreshPolicy` property on the table to `True`:
 
   <br></br>
 
@@ -54,16 +53,16 @@ To set up Incremental Refresh, you must configure a new Refresh Policy for the t
 
   <br></br>
 
-6. Configure the remaining properties according to the incremental refresh policy you need. Remember to specify an M expression for the `SourceExpression` property (this is the expression that will be added to partititions created by the incremental refresh policy, which should use the `RangeStart` and `RangeEnd` parameters to filter the data in the source). The = operator should only be applied to either RangeStart or RangeEnd, but not both, as data may be duplicated.
+5. __Configure Refresh Policy:__ Configure the remaining properties according to the incremental refresh policy you need. Remember to specify an M expression for the `SourceExpression` property (this is the expression that will be added to partititions created by the incremental refresh policy, which should use the `RangeStart` and `RangeEnd` parameters to filter the data in the source). The = operator should only be applied to either RangeStart or RangeEnd, but not both, as data may be duplicated.
 
-  - __Source Expression:__ The M Expression that be added to partitions created by the Refresh Policy.
-  - __IncrementalWindowGranularity:__ The granularity of the incremental (refresh) window.
-  - __IncrementalWindowPeriods:__ # periods (of granularity specified above) wherein data should be refreshed.
-  - __IncrementalWindowPeriodsOffset:__ Set to `-1` to set _'Only Refresh Complete Periods'_
-  - __RollingWindowGranularity:__ The granularity of the rolling (archive) window.
-  - __RollingWindowPeriods:__ # periods (of granularity specified above) wherein data should be archived.
-  - __Mode:__ Whether it is standard `Import` Refresh Policy or `Hybrid`, where the last partition is DirectQuery.
-  - __PollingExpression:__ A valid M Expression configured to detect data changes. For more information about _Polling Expression_ or other Refresh Policy properties, see [here](xref:incremental-refresh-about#overview-of-all-properties).
+    - __Source Expression:__ The M Expression that be added to partitions created by the Refresh Policy.
+    - __IncrementalWindowGranularity:__ The granularity of the incremental (refresh) window.
+    - __IncrementalWindowPeriods:__ # periods (of granularity specified above) wherein data should be refreshed.
+    - __IncrementalWindowPeriodsOffset:__ Set to `-1` to set _'Only Refresh Complete Periods'_
+    - __RollingWindowGranularity:__ The granularity of the rolling (archive) window.
+    - __RollingWindowPeriods:__ # periods (of granularity specified above) wherein data should be archived.
+    - __Mode:__ Whether it is standard `Import` Refresh Policy or `Hybrid`, where the last partition is DirectQuery.
+    - __PollingExpression:__ A valid M Expression configured to detect data changes. For more information about _Polling Expression_ or other Refresh Policy properties, see [here](xref:incremental-refresh-about#overview-of-all-properties).
   
   <br></br>
 
@@ -71,8 +70,8 @@ To set up Incremental Refresh, you must configure a new Refresh Policy for the t
   
   <br></br>
 
-7. Save your model (Ctrl+S).
-8. Right-click on the table and choose "Apply Refresh Policy".
+6. __Apply Model Changes:__ Save your model (Ctrl+S).
+7. __Apply Refresh Policy:__ Right-click on the table and choose "Apply Refresh Policy".
 
   <br></br>
   
@@ -88,7 +87,7 @@ To set up Incremental Refresh, you must configure a new Refresh Policy for the t
   
   <br></br>
 
-9. __Refresh all partitions:__ Select and right-click all partitions. Select _Refresh > Full refresh (partition)_.
+8. __Refresh all partitions:__ Shift-click to select all partitions. Right-click and select _Refresh > Full refresh (partition)_.
 
   <br></br>
 

--- a/te3/tutorials/incremental-refresh-workspace-mode.md
+++ b/te3/tutorials/incremental-refresh-workspace-mode.md
@@ -41,3 +41,5 @@ To deploy the model, go _Model > Deploy..._ which opens the Deployment Wizard. H
   ![Incremental Refresh Workspace Mode Visual Abstract](../../images/incremental-refresh-deploy-partitions.png)
 
   <br></br>
+
+By deploying the model without these Policy Range partitions, you are mitigating any potential impact due to out-of-sync incremental refresh partitions between the metadata and remote model.


### PR DESCRIPTION
Some typos & formatting fixes for clarification. 

- RangeStart and RangeEnd Source Expression filter steps had the ">" and "<" signs reversed, accidentally
- Clarifications when the dtypes of RangeStart / RangeEnd and the date column don't match (date col is string, int, date)
- 'Modify an Existing Refresh Policy' had a typo regarding using the EffectiveDate parameter that referred to TE2 instead of TE3
- 'Set Up a New Refresh Policy' lacked a step to explain the addition of the filter step.
- 'Workspace Mode' article needed a concluding sentence.
- Misc small formatting changes