### PR TITLE
TMDL clarification 

### DIFF
--- a/te3/features/tmdl.md
+++ b/te3/features/tmdl.md
@@ -23,7 +23,7 @@ applies_to:
 
 ## Enabling TMDL (Preview) in Tabular Editor 3
 
-TMDL is only available as a preview feature in Tabular Editor 3. To enable TMDL (Preview) in Tabular Editor 3, go to **Tools > Preferences > File Formats > Save-to-folder**, and select "TMDL (preview)" in the **Serialization mode** dropdown. The legacy "save-to-folder" functionally will continue to exist side by side with TMDL, but is not a Microsoft supported format.
+TMDL is only available as a preview feature in Tabular Editor 3. To enable TMDL (Preview) in Tabular Editor 3, go to **Tools > Preferences > File Formats > Save-to-folder**, and select "TMDL (preview)" in the **Serialization mode** dropdown. The legacy "save-to-folder" functionality will continue to exist side by side with TMDL, but is not a Microsoft supported format.
 
 After doing so, Tabular Editor 3 will use the TMDL format when saving a model as a folder (**File > Save to folder...**).
 

--- a/te3/features/tmdl.md
+++ b/te3/features/tmdl.md
@@ -23,7 +23,7 @@ applies_to:
 
 ## Enabling TMDL (Preview) in Tabular Editor 3
 
-TMDL is only available as a preview feature in Tabular Editor 3. To enable TMDL (Preview) in Tabular Editor 3, go to **Tools > Preferences > File Formats > Save-to-folder**, and select "TMDL (preview)" in the **Serialization mode** dropdown. The legacy "save-to-folder" functionally will continue to exists side by side with TMDL, but is not a Microsoft supported format.
+TMDL is only available as a preview feature in Tabular Editor 3. To enable TMDL (Preview) in Tabular Editor 3, go to **Tools > Preferences > File Formats > Save-to-folder**, and select "TMDL (preview)" in the **Serialization mode** dropdown. The legacy "save-to-folder" functionally will continue to exist side by side with TMDL, but is not a Microsoft supported format.
 
 After doing so, Tabular Editor 3 will use the TMDL format when saving a model as a folder (**File > Save to folder...**).
 

--- a/te3/features/tmdl.md
+++ b/te3/features/tmdl.md
@@ -23,7 +23,7 @@ applies_to:
 
 ## Enabling TMDL (Preview) in Tabular Editor 3
 
-Once TMDL is fully supported by the entire Microsoft ecosystem, we plan to deprecate Tabular Editor's legacy "save-to-folder" functionality, in order to fully embrace TMDL as the de-facto standard for storing model metadata. However, until then, TMDL is only available as a preview feature in Tabular Editor 3. To enable TMDL (Preview) in Tabular Editor 3, go to **Tools > Preferences > File Formats > Save-to-folder**, and select "TMDL (preview)" in the **Serialization mode** dropdown.
+TMDL is only available as a preview feature in Tabular Editor 3. To enable TMDL (Preview) in Tabular Editor 3, go to **Tools > Preferences > File Formats > Save-to-folder**, and select "TMDL (preview)" in the **Serialization mode** dropdown. The legacy "save-to-folder" functionally will continue to exists side by side with TMDL, but is not a Microsoft supported format.
 
 After doing so, Tabular Editor 3 will use the TMDL format when saving a model as a folder (**File > Save to folder...**).
 


### PR DESCRIPTION
Clarifying a wrong formulation on the legacy .json format.