### PR TITLE
Update Roadmap, XLMA Workaround & TMDL overview

### DIFF
--- a/te3/features/tmdl.md
+++ b/te3/features/tmdl.md
@@ -14,14 +14,7 @@ applies_to:
 
 **TMDL** is a model metadata file format [announced by Microsoft in April 2023](https://powerbi.microsoft.com/en-ie/blog/announcing-public-preview-of-the-tabular-model-definition-language-tmdl/). It aims to provide a human-readable, text-based alternative to the JSON-based model.bim file format. TMDL is inspired by YAML, and as such, is easy to read and write, with minimal use of string quotes and escape characters. It also serializes a model as several smaller files in a folder structure, and is therefore also better suited for version control integration.
 
-> [!IMPORTANT]
-> As of February 2024, TMDL is still a preview feature. It is currently only supported by community tools such as Tabular Editor and [pbi-tools](https://pbi.tools/). However, the format is fully documented and available through [Microsoft-provided nuget packages](https://www.nuget.org/packages/Microsoft.AnalysisServices.Tabular.Tmdl.retail.amd64/19.64.0-TmdlPreview).
-
-> [!TIP]
-> Since TMDL is a preview feature, breaking changes could be introduced between new releases of Tabular Editor. If you face any issues deserializing a model after upgrading Tabular Editor, rollback to the latest version of Tabular Editor, then temporarily save the model as a regular .bim file, before serializing it to TMDL again using the latest version of Tabular Editor.
-
-
-## Enabling TMDL (Preview) in Tabular Editor 3
+## Enabling TMDL in Tabular Editor 3
 
 TMDL is only available as a preview feature in Tabular Editor 3. To enable TMDL (Preview) in Tabular Editor 3, go to **Tools > Preferences > File Formats > Save-to-folder**, and select "TMDL (preview)" in the **Serialization mode** dropdown. The legacy "save-to-folder" functionality will continue to exist side by side with TMDL, but is not a Microsoft supported format.
 

--- a/te3/features/tmdl.md
+++ b/te3/features/tmdl.md
@@ -16,7 +16,7 @@ applies_to:
 
 ## Enabling TMDL in Tabular Editor 3
 
-TMDL is only available as a preview feature in Tabular Editor 3. To enable TMDL (Preview) in Tabular Editor 3, go to **Tools > Preferences > File Formats > Save-to-folder**, and select "TMDL (preview)" in the **Serialization mode** dropdown. The legacy "save-to-folder" functionality will continue to exist side by side with TMDL, but is not a Microsoft supported format.
+To enable TMDL in Tabular Editor 3, go to **Tools > Preferences > File Formats > Save-to-folder**, and select "TMDL" in the **Serialization mode** dropdown. The legacy "save-to-folder" functionality will continue to exist side by side with TMDL, but is not a Microsoft supported format.
 
 After doing so, Tabular Editor 3 will use the TMDL format when saving a model as a folder (**File > Save to folder...**).
 
@@ -31,5 +31,5 @@ When saving a new model for the first time, Tabular Editor (since v. 3.7.0), wil
 
 # Next steps
 
-- [TMDL overview (Microsoft Learn)](https://learn.microsoft.com/en-us/analysis-services/tmdl/tmdl-overview?view=asallproducts-allversions).
-- [Get started with TMDL (Microsoft Learn)](https://learn.microsoft.com/en-us/analysis-services/tmdl/tmdl-how-to?view=asallproducts-allversions)
+- [TMDL overview (Microsoft Learn)](https://learn.microsoft.com/en-us/analysis-services/tmdl/tmdl-overview).
+- [Get started with TMDL (Microsoft Learn)](https://learn.microsoft.com/en-us/analysis-services/tmdl/tmdl-how-to)

--- a/te3/other/roadmap.md
+++ b/te3/other/roadmap.md
@@ -8,13 +8,13 @@ updated: 2024-09-06
 
 Below is an overview of major new features to be shipped with Tabular Editor 3 updates in the short- to long term:
 
+
+
 # [Planned 2024](#tab/PlannedQ4)
 
-- More Daxscilla code refactoring options and automatic suggestions (for example, replace identical subexpressions with 
-a variable)
-- TMDL GA Support
-- Diagram Improvements
-- GA of DAX Optimizer Integration
+- Data Refresh View Improvements
+- Power Query (M) Highlighting
+
 
 ## Shipped in 2024
 ✅ DAX Debugger Locals Enhancement
@@ -23,16 +23,28 @@ a variable)
 ✅ .Net 8 migration
 ✅ Pivot Grid Enhancement
 ✅ DAX Query Enhancement
+✅ TMDL GA Support
+✅ Code Actions
+✅ GA of DAX Optimizer Integration
 
+# [Planned 2025](#tab/Planned2025)
+
+- Adding more Macro Actions
+- Built in Best Practice Rules
+- Built in Macros
+- Power Query (M) Auto-Formatting
 
 # [Future Features](#tab/FutureFeatures)
 
+## Up Next
+- Localization
+- Power Query (M) Editing Enchantments
+- Macro Actions improvements such as automatic application across model and preferences for which to apply.
 
 ## Non Planned Features
-- Localization
-- Built in Macros and Best Practice Rules
+
 - Standalone CLI application
-- Git integration
+- GIT integration
 - DAX Debugger Filter Context visualizer
 - Configurable Daxscilla autocomplete code snippets
 - Configurable theming for code editors (syntax highlighting colors)

--- a/te3/powerbi-xmla-pbix-workaround.md
+++ b/te3/powerbi-xmla-pbix-workaround.md
@@ -47,6 +47,9 @@ This will save the remote model into the Power BI Project that will now contain 
 ## Step 3.1: Remove incremental refresh partitions and create new (Optional)
 Use the Convert Incremental Refresh script below to delete incremental refresh partitions and create a single partition for each table containing the expression used in the incremental refresh expression.
 
+## Step 3.2: Save into .pbip using TMDL
+
+If the .pbip folder is configured to store the model as [TMDL](xref:tmdl) files, you will need to use the Save To Folder option in Tabular Editor instead. Then navigate to the Power BI project folder for the semantic model (ModelName.SemanticModel), open the 'definition' folder and save your model there.
 
 ## Step 4: Save to .pbix and open this file in Power BI Desktop
 

--- a/te3/powerbi-xmla-pbix-workaround.md
+++ b/te3/powerbi-xmla-pbix-workaround.md
@@ -44,12 +44,13 @@ In Tabular Editor using _File > Save as..._, navigate to the Power BI Project fo
 
 This will save the remote model into the Power BI Project that will now contain the model metadata.
 
+If the .pbip folder is configured to store the model as [TMDL](xref:tmdl) files, you will need to use the Save To Folder option in Tabular Editor instead. Then navigate to the Power BI project folder for the semantic model (ModelName.SemanticModel), open the 'definition' folder and save your model there.
+
+> [!NOTE]
+> To enable TMDL go to **Tools > Preferences > File Formats > Save-to-folder**, and select "TMDL" in the **Serialization mode** dropdown. See [TMDL documentation for more information](xrefid:tmdl)
+
 ## Step 3.1: Remove incremental refresh partitions and create new (Optional)
 Use the Convert Incremental Refresh script below to delete incremental refresh partitions and create a single partition for each table containing the expression used in the incremental refresh expression.
-
-## Step 3.2: Save into .pbip using TMDL
-
-If the .pbip folder is configured to store the model as [TMDL](xref:tmdl) files, you will need to use the Save To Folder option in Tabular Editor instead. Then navigate to the Power BI project folder for the semantic model (ModelName.SemanticModel), open the 'definition' folder and save your model there.
 
 ## Step 4: Save to .pbix and open this file in Power BI Desktop
 
@@ -63,7 +64,7 @@ Save it to a .pbix using _File > Save As..._ in Power BI Desktop.
 The .pbix now contains the model that was published to the Fabric workspace. When you open the .pbix, you can _re-hydrate_ the file, meaning that you load the data based on the connections specified in the model.
 
 ## Convert Incremental Refresh partitions
-The above step 4 will fail if the semantic model has incremental refresh enabled as a Power BI desktop model cannot contain multiple partitions. 
+The above step 4 will fail if the semantic model has incremental refresh enabled as a Power BI desktop model cannot contain multiple partitions.
 In this case the following script should be run against the model to convert incremental refresh partitions into single partitions
 
 

--- a/te3/powerbi-xmla-pbix-workaround.md
+++ b/te3/powerbi-xmla-pbix-workaround.md
@@ -47,7 +47,7 @@ This will save the remote model into the Power BI Project that will now contain 
 If the .pbip folder is configured to store the model as [TMDL](xref:tmdl) files, you will need to use the Save To Folder option in Tabular Editor instead. Then navigate to the Power BI project folder for the semantic model (ModelName.SemanticModel), open the 'definition' folder and save your model there.
 
 > [!NOTE]
-> To enable TMDL go to **Tools > Preferences > File Formats > Save-to-folder**, and select "TMDL" in the **Serialization mode** dropdown. See [TMDL documentation for more information](xrefid:tmdl)
+> To enable TMDL go to **Tools > Preferences > File Formats > Save-to-folder**, and select "TMDL" in the **Serialization mode** dropdown. See [TMDL documentation for more information](xref:tmdl)
 
 ## Step 3.1: Remove incremental refresh partitions and create new (Optional)
 Use the Convert Incremental Refresh script below to delete incremental refresh partitions and create a single partition for each table containing the expression used in the incremental refresh expression.


### PR DESCRIPTION
Update of Roadmap
Update of TMDL overview to remove preview refernces.
Update the workaround to include a specification of how to use TMDL instead of the .bim file