### PR TITLE
Add known limitation for Sort By columns in Calendar Editor

### DIFF
--- a/content/tutorials/calendars.md
+++ b/content/tutorials/calendars.md
@@ -160,11 +160,19 @@ Associated columns receive the same filter behavior as the primary column during
 > [!WARNING]
 > **Known limitation: Sort By columns and Associated columns**
 >
+> &nbsp;
+>
 > When a column is used as a **Sort By** column for a Primary time unit column, Analysis Services implicitly treats it as an Associated column. You should **not** explicitly add that Sort By column as an Associated column in the Calendar Editor, as this will cause an error from Analysis Services (duplicate mapping).
+>
+> &nbsp;
 >
 > For example, if you set `MonthName` as the Primary column for "Month of Year" and `MonthName` has `MonthNumber` configured as its Sort By column, then `MonthNumber` is implicitly associated. In this case, you do not need to (and should not) add `MonthNumber` as an explicit Associated column. The Sort By column will still provide the expected enhanced calendar behavior (including proper `REMOVEFILTERS()` handling) since the association is inferred.
 >
+> &nbsp;
+>
 > Note that this behavior is asymmetric: if you instead set the Sort By column (e.g., `MonthNumber`) as the Primary time unit column, then the display column (e.g., `MonthName`) is **not** automatically treated as Associated. In that scenario, you can explicitly add the display column as an Associated column if desired.
+>
+> &nbsp;
 >
 > A future version of Tabular Editor will add validation to prevent this configuration error.
 


### PR DESCRIPTION
## Summary

- Documents a known limitation where Sort By columns cannot be explicitly added as Associated columns when already used with a Primary time unit column
- Explains that Analysis Services implicitly treats Sort By columns as Associated, causing duplicate mapping errors if added explicitly
- Clarifies the asymmetric behavior when the Sort By column is set as Primary instead

---
Generated with [Claude Code](https://claude.com/claude-code)