### PR TITLE
use relative paths to avoid invalid redirect to generic.html, fix bad…

### DIFF
--- a/content/whats-new/3-22-0.html
+++ b/content/whats-new/3-22-0.html
@@ -1,10 +1,10 @@
 <h2>Tabular Editor 3.22.0</h2>
 <p>Release blog: <a href="https://tabulareditor.com/blog/tabular-editor-3-june-2025-release">June 2025</a> (v. 3.22.0, <a href="https://docs.tabulareditor.com/te3/other/release-notes/3_22_0.html">release notes</a>)</p>
 <ul>
-    <li>Enhanced Direct Lake support — Build Direct Lake models faster with easier setup for Fabric Lakehouses/Warehouses and new OneLake connector support.</li>
-    <li>New composite models (Direct Lake + Import) — Seamlessly combine Direct Lake for large fact tables with Import mode for dimension tables in the same model.</li>
-    <li>Full modeling in Desktop Edition — Unlock all semantic modeling capabilities when connected to Power BI Desktop, including modifying M expressions and managing partitions.</li>
-    <li>Smarter DAX auto-complete — Find measures, columns, and tables faster with improved, word-based search in the DAX editor.</li>
+    <li>Enhanced Direct Lake support &mdash; Build Direct Lake models faster with easier setup for Fabric Lakehouses/Warehouses and new OneLake connector support.</li>
+    <li>New composite models (Direct Lake + Import) &mdash; Seamlessly combine Direct Lake for large fact tables with Import mode for dimension tables in the same model.</li>
+    <li>Full modeling in Desktop Edition &mdash; Unlock all semantic modeling capabilities when connected to Power BI Desktop, including modifying M expressions and managing partitions.</li>
+    <li>Smarter DAX auto-complete &mdash; Find measures, columns, and tables faster with improved, word-based search in the DAX editor.</li>
     
     <li><a href="https://docs.tabulareditor.com/te3/other/release-notes/3_22_0.html">And more...</a></li>
 </ul>

--- a/content/whats-new/3-22-1.html
+++ b/content/whats-new/3-22-1.html
@@ -1,10 +1,10 @@
 <h2>Tabular Editor 3.22.1</h2>
 <p>Release blog: <a href="https://tabulareditor.com/blog/tabular-editor-3-june-2025-release">June 2025</a> (v. 3.22.1, <a href="https://docs.tabulareditor.com/te3/other/release-notes/3_22_1.html">release notes</a>)</p>
 <ul>
-    <li>Enhanced Direct Lake support — Build Direct Lake models faster with easier setup for Fabric Lakehouses/Warehouses and new OneLake connector support.</li>
-    <li>New composite models (Direct Lake + Import) — Seamlessly combine Direct Lake for large fact tables with Import mode for dimension tables in the same model.</li>
-    <li>Full modeling in Desktop Edition — Unlock all semantic modeling capabilities when connected to Power BI Desktop, including modifying M expressions and managing partitions.</li>
-    <li>Smarter DAX auto-complete — Find measures, columns, and tables faster with improved, word-based search in the DAX editor.</li>
+    <li>Enhanced Direct Lake support &mdash; Build Direct Lake models faster with easier setup for Fabric Lakehouses/Warehouses and new OneLake connector support.</li>
+    <li>New composite models (Direct Lake + Import) &mdash; Seamlessly combine Direct Lake for large fact tables with Import mode for dimension tables in the same model.</li>
+    <li>Full modeling in Desktop Edition &mdash; Unlock all semantic modeling capabilities when connected to Power BI Desktop, including modifying M expressions and managing partitions.</li>
+    <li>Smarter DAX auto-complete &mdash; Find measures, columns, and tables faster with improved, word-based search in the DAX editor.</li>
     
     <li><a href="https://docs.tabulareditor.com/te3/other/release-notes/3_22_1.html">And more...</a></li>
 </ul>

--- a/content/whats-new/generic.html
+++ b/content/whats-new/generic.html
@@ -6,10 +6,10 @@
         <li>Getting oriented in Tabular Editor</li>
         <li>End-to-end with Tabular Editor</li>
     </ul>
-    <p style="margin:0; font-weight:600;"><a href="https://learn.tabulareditor.com/beginnercourse" target="_blank" style="text-decoration:none;">Start the beginner course now →</a></p>
+    <p style="margin:0; font-weight:600;"><a href="https://learn.tabulareditor.com/beginnercourse" target="_blank" style="text-decoration:none;">Start the beginner course now &rarr;</a></p>
 <p>Want to explore specific areas instead? Try these quick resources:</p>
 <ul>
-    <li><a href="https://youtu.be/O4ATwdzCvWc" target="_blank">25‑minute tour with Kurt Buhler</a></li>
+    <li><a href="https://youtu.be/O4ATwdzCvWc" target="_blank">25-minute tour with Kurt Buhler</a></li>
     <li><a href="https://docs.tabulareditor.com/onboarding/importing-tables-data-modeling.html">Import tables & model structure</a></li>
     <li><a href="https://docs.tabulareditor.com/onboarding/refresh-preview-query.html">Refresh, preview & query data</a></li>
     <li><a href="https://docs.tabulareditor.com/onboarding/dax-script-introduction.html">Intro to DAX scripting</a></li>

--- a/content/whats-new/index.html
+++ b/content/whats-new/index.html
@@ -106,7 +106,7 @@
       function init() {
         var version = getParameterByName("version");
         if (!version) version = "generic"; else if (is_3_18_orGreater(version)) { deleteElementById("dax-optimizer-banner"); }
-        loadDivContent("/whats-new/" + urlify(version) + ".html", "version-specific-content");
+        loadDivContent(urlify(version) + ".html", "version-specific-content");
         applyStyle();
       }
       function is_3_18_orGreater(version) { const parts = version.split('.'); return parseInt(parts[0], 10) >= 3 && parseInt(parts[1], 10) >= 18; }


### PR DESCRIPTION
 1. After the multi-language migration, index.html lives at /en/whats-new/index.html
  2. The JavaScript on line 109 makes an XHR to an absolute path: /whats-new/generic.html (no /en/ prefix)
  3. The build process (generate_lang_prefix_redirect_pages) creates a redirect stub at /whats-new/generic.html
  containing <meta http-equiv="refresh" content="0;URL='/en/whats-new/generic.html'">
  4. The XHR gets back this meta-refresh HTML and injects it into the DOM via innerHTML
  5. The browser follows the meta-refresh and navigates to /en/whats-new/generic.html directly — losing all the
  layout/JS from index.html

  The fix is to change the absolute path to a relative one so it resolves correctly under /en/whats-new/

Also fixed bad UTF-8 chars in some .html files