### PR TITLE
Adding new documentation

### DIFF
--- a/content/features/views/user-interface.md
+++ b/content/features/views/user-interface.md
@@ -49,6 +49,28 @@ Use the **Window > Capture current layout..." option to save a customized layout
 
 ![Manage Layouts](~/content/assets/images/manage-layouts.png)
 
+### Window docking options
+
+When rearranging views and documents in Tabular Editor 3, you can choose to dock windows in different areas of the interface. When dragging a window to a new position, docking indicators will appear showing you the available docking locations.
+
+![Window Docking Options](~/content/assets/images/window-docking-options.png)
+
+There are two primary ways to dock windows, each serving a different purpose:
+
+**Document tab docking (center indicator)**: When you drag a window to the center docking indicator, it will be placed in the main document area. Windows docked this way become document tabs that:
+- Can be cycled through using **Ctrl+Tab**
+- Are displayed in the main working area alongside other documents like DAX queries, scripts, and diagrams
+- Do not have auto-hide functionality
+
+**Tool window docking (edge indicators)**: When you drag a window to the left, right, top, or bottom docking indicators, it will be docked as a tool window. Tool windows:
+- Are not accessible via **Ctrl+Tab**
+- Display a pin icon that enables auto-hide functionality (making the window collapse when not in use)
+- Behave similarly to other tool windows such as the TOM Explorer and Messages view
+- Can be docked at various positions around the main document area
+
+> [!TIP]
+> The size of a docked window is determined by the available space in the area you choose to dock it, not by the docking option itself. You can resize windows by dragging the dividers between them.
+
 ### Changing themes and palettes
 
 The visual appearance of Tabular Editor 3 can be changed by choosing a different theme and/or palette. Tabular Editor 3 ships with five different themes (sometimes called "skins"), available through the **Window > Themes** menu:

--- a/content/references/shortcuts3.md
+++ b/content/references/shortcuts3.md
@@ -31,6 +31,7 @@ applies_to:
 |Close Document|Ctrl+W|
 |Exit|Alt+F4|
 |Deployment wizard|Ctrl+Shift+D|
+|Switch In-Focus Window|Ctrl+Tab|
 
 ## Edit
 

--- a/content/troubleshooting/composite-model-measure-formatting.md
+++ b/content/troubleshooting/composite-model-measure-formatting.md
@@ -1,0 +1,225 @@
+---
+uid: composite-model-measure-formatting
+title: Measure Format Properties in Composite Models
+author: Support Team
+updated: 2026-01-26
+applies_to:
+  products:
+    - product: Tabular Editor 2
+      full: true
+    - product: Tabular Editor 3
+      editions:
+        - edition: Desktop
+          full: true
+        - edition: Business
+          full: true
+        - edition: Enterprise
+          full: true
+---
+
+# Measure Format Properties in Composite Models
+
+When working with composite models that use a Live connection to Analysis Services (SSAS/AAS), you may encounter validation errors or confusing behavior when editing measure formatting properties. A common error message is:
+
+**"A measure is not allowed to have both FormatString and Format Expression."**
+
+This article explains why this occurs and how to resolve it.
+
+---
+
+## Understanding the Issue
+
+Composite models combine local Power BI tables with remote tables from an SSAS/AAS semantic model via a Live connection. In this architecture, measure formatting can be ambiguous:
+
+- **FormatString**: A static format definition (e.g., "0.00" for currency).
+- **Format String Expression**: A dynamic format string evaluated at query time.
+
+The error occurs because the model ends up with both a static format and a dynamic format expression simultaneously—a state that is not allowed by the Tabular Object Model (TOM).
+
+### Why this happens
+
+In composite models:
+
+1. **Ownership ambiguity**: Remote measures are owned by the remote SSAS/AAS model. When you edit formatting in Tabular Editor, you may be trying to override remote metadata, which creates conflicts.
+
+2. **Metadata synchronization**: When a Format String Expression is present on a measure, the FormatString often appears as "Custom" to indicate dynamic formatting is active. If you then try to set a static FormatString simultaneously, both properties become populated, triggering the validation error.
+
+3. **Persistence constraints**: Changes to remote measure metadata may not persist cleanly because the remote model retains authoritative control. This leaves the local composite model in an inconsistent state.
+
+---
+
+## Root Causes
+
+### Remote measure formatting
+
+If the problematic measure is defined in the remote SSAS/AAS model:
+
+- Formatting should be managed in the source model, not in the Power BI composite model.
+- Attempting to override remote measure formatting in Power BI can result in both FormatString and Format String Expression being populated, leading to the validation error.
+
+### Script or automation setting both properties
+
+- If you are using C# scripts, Power Query transformations, or BPA rules to apply formatting, ensure they target only one approach per measure (either static or dynamic, not both).
+
+### Calculation groups with format expressions
+
+- Calculation groups can define Format String Expressions that override measure formats. If a calc item's format expression is active, the UI may still display the measure's static FormatString, creating the appearance of both being set.
+
+### Version or environment constraints
+
+- Dynamic format strings for measures have limited availability and may not be fully supported in certain Power BI versions or deployment modes (Report Server).
+- If you are on Power BI Desktop prior to 2025 or Power BI Report Server prior to January 2025, dynamic measure formats may not be supported.
+
+---
+
+## Resolution
+
+The solution depends on whether the measure is **remote** (from SSAS/AAS) or **local** (created in the composite model).
+
+### If the measure is remote (from SSAS/AAS)
+
+This is the most common scenario. Remote measures are owned by the source semantic model.
+
+**Recommended approach:**
+
+1. **Manage formatting in the source model.** Open SSAS/AAS in SQL Server Management Studio or Tabular Editor connected to the source model, and set the formatting there.
+
+2. **If report-specific formatting is required,** create a local "wrapper" measure in your Power BI composite model:
+   - Define a new measure in the local model that references the remote measure.
+   - Apply the desired format string to the wrapper measure.
+   - Use the wrapper measure in your report instead of the remote measure.
+
+   **Trade-off:** This approach creates duplicates and adds maintenance overhead, but it is the most reliable way to apply report-specific formatting in a Live connection scenario.
+
+### If the measure is local (created in the composite model)
+
+**For static formatting (most common):**
+
+1. Select the measure in Tabular Editor.
+2. Clear the **Format String Expression** field (set it to empty/null).
+3. Set the measure's **Format String** to the desired static format (e.g., `"0.00%"` for percentage, `"$#,##0.00"` for currency).
+4. Save the model.
+
+**For dynamic formatting:**
+
+1. Select the measure.
+2. Keep or set the **Format String Expression** to your desired DAX expression (this is the only formatting property you should use).
+3. Leave the **Format String** as "Custom" (do not attempt to also set a static format string).
+4. Verify that your environment supports dynamic format strings (Power BI Desktop 2025 or later, or Power BI Report Server January 2025 or later).
+
+---
+
+## Quick Troubleshooting Checklist
+
+- [ ] **Determine measure ownership**: Is the measure remote (SSAS/AAS) or local (composite model)?
+- [ ] **Check Format String Expression**: Even if you didn't set it, verify whether it is populated. In the property grid, look for a non-empty "Format String Expression" field.
+- [ ] **Review scripts and rules**: If you use C# scripts or BPA rules to set measure formats, ensure they do not set both FormatString and Format String Expression in the same pass.
+- [ ] **Check calculation groups**: Confirm whether any calculation group items define a Format String Expression that might be overriding or conflicting with the measure's format.
+- [ ] **Verify environment version**: Confirm your Power BI Desktop (2025 or later) or Power BI Report Server (January 2025 or later) version, especially if using dynamic formats.
+
+---
+
+## Step-by-Step Examples
+
+### Example 1: Fixing a remote measure with static formatting
+
+**Scenario:** You have a "Sales Amount" measure in the remote SSAS model, and you want it formatted as currency in your Power BI report.
+
+**Steps:**
+
+1. In Tabular Editor, connect directly to the SSAS/AAS model (not to the Power BI composite model).
+2. Navigate to the "Sales Amount" measure.
+3. Set its **Format String** to `"$#,##0.00"`.
+4. Save the model back to SSAS/AAS.
+5. Return to Tabular Editor connected to the Power BI composite model; the formatting should now be inherited.
+
+If formatting still does not appear correct in the report, create a local wrapper measure (see below).
+
+### Example 2: Creating a wrapper measure for report-specific formatting
+
+**Scenario:** You need the Sales Amount measure from SSAS formatted differently in this specific report.
+
+**Steps:**
+
+1. In Tabular Editor, connect to the Power BI composite model.
+2. Create a new measure in a local table (or in the measure table if you have one):
+   ```
+   Sales Amount (Formatted) = [Sales Amount]
+   ```
+3. Set the **Format String** of the new measure to your desired format (e.g., `"$#,##0.00"`).
+4. Save the model.
+5. Update your report visuals to use the wrapper measure instead of the original remote measure.
+
+### Example 3: Setting local measure with dynamic formatting
+
+**Scenario:** You have a local measure in the composite model and want to apply conditional formatting based on a threshold.
+
+**Steps:**
+
+1. Select the measure in Tabular Editor.
+2. Ensure **Format String** is empty (do not set a static format).
+3. Set **Format String Expression** to your conditional expression:
+   ```dax
+   IF(
+       [YourMeasure] > 1000,
+       "#,##0.00",
+       "0.00"
+   )
+   ```
+4. Do **not** also set a static FormatString.
+5. Save the model.
+6. Verify your Power BI version supports dynamic format strings (Desktop 2025+ or PBIRS Jan 2025+).
+
+---
+
+## Prevention Best Practices
+
+1. **Decide on formatting strategy early**: Determine whether each measure should use static or dynamic formatting and stick to one approach per measure.
+
+2. **Audit remote measures**: Before editing formatting in a composite model, check whether the measure is remote. If so, manage formatting in the source SSAS/AAS model.
+
+3. **Use version-appropriate features**: If you're using dynamic format strings, ensure all relevant environments (Desktop, Report Server, Analysis Services) support them for your Power BI version.
+
+4. **Script defensively**: If you write C# scripts or BPA rules to format measures, separate the logic so you only set one for mat property per measure, and include a guard to check whether the other property is already populated.
+
+5. **Clear Format String Expression when switching to static**: If a measure previously used dynamic formatting, always clear the Format String Expression before attempting to set a static FormatString.
+
+---
+
+## Additional Resources
+
+- **[Microsoft Docs - Measure Format Strings](https://learn.microsoft.com/en-us/analysis-services/tmsl/measures-object-tmsl)**: Official documentation on measure formatting in the Tabular Object Model.
+- **[Composite Models in Power BI](https://learn.microsoft.com/en-us/power-bi/transform-model/desktop-composite-models)**: Understanding Live connections and composite model architecture.
+- **[Dynamic Format Strings](https://learn.microsoft.com/en-us/power-bi/create-reports/desktop-dynamic-format-strings)**: Feature availability and usage guidance.
+
+---
+
+## Still Need Help?
+
+If the steps above don't resolve your issue:
+
+1. **Verify the measure is local**: Connect directly to your Power BI file (.pbix) in Tabular Editor to confirm the measure is defined locally, not remotely.
+
+2. **Export diagnostic information**: Run the following Tabular Editor script to audit all measures:
+   ```csharp
+   var measures = Model.AllMeasures;
+   foreach (var m in measures)
+   {
+       var hasStaticFormat = !string.IsNullOrEmpty(m.FormatString);
+       var hasDynamicFormat = !string.IsNullOrEmpty(m.FormatStringExpression);
+       if (hasStaticFormat && hasDynamicFormat)
+       {
+           Output($"CONFLICT - {m.Name}: FormatString='{m.FormatString}', Expression='{m.FormatStringExpression}'");
+       }
+       else if (hasStaticFormat)
+       {
+           Output($"STATIC - {m.Name}: '{m.FormatString}'");
+       }
+       else if (hasDynamicFormat)
+       {
+           Output($"DYNAMIC - {m.Name}: '{m.FormatStringExpression}'");
+       }
+   }
+   ```
+
+3. **Contact support**: Reach out with the diagnostic output and your Power BI and Tabular Editor version numbers.

--- a/content/troubleshooting/databricks-column-comments-length.md
+++ b/content/troubleshooting/databricks-column-comments-length.md
@@ -1,0 +1,210 @@
+---
+uid: databricks-column-comments-length
+title: Databricks Column Comment Length Error
+author: Support Team
+updated: 2026-02-06
+applies_to:
+  products:
+    - product: Tabular Editor 2
+      none: true
+    - product: Tabular Editor 3
+      editions:
+        - edition: Desktop
+          full: true
+        - edition: Business
+          full: true
+        - edition: Enterprise
+          full: true
+---
+
+# Databricks Column Comment Length Error
+
+When using the Import Table Wizard to import tables from Databricks, you may encounter a connection error if column comments (descriptions) exceed 512 characters. This limitation exists in the Simba Spark ODBC Driver, even though Databricks Unity Catalog allows longer column comments.
+
+A typical error message looks like:
+
+**"Unable to connect to database 'database_name' on 'adb-xxxx.azuredatabricks.net/sql/1.0/warehouses/xxxx': Exception has been thrown by the target of an invocation."**
+
+This article explains why this occurs and provides two workarounds to resolve the issue.
+
+---
+
+## Understanding the Issue
+
+The Simba Spark ODBC Driver, which Tabular Editor uses to connect to Databricks, has a default limit of 512 characters for column comments. This limit is enforced regardless of what Databricks Unity Catalog allows.
+
+### Why this happens
+
+1. **Default driver limitation**: The Simba Spark ODBC Driver is configured with a default `MaxCommentLen` parameter of 512 characters.
+
+2. **Unity Catalog allows longer comments**: Databricks Unity Catalog permits column descriptions longer than 512 characters, which can exceed the driver's limit.
+
+3. **Import wizard retrieval**: When the Import Table Wizard queries table metadata, it attempts to retrieve all column comments. If any comment exceeds the driver's limit, the connection fails with an invocation exception.
+
+---
+
+## Resolution
+
+There are two approaches to resolve this issue:
+
+### Option 1: Limit column comments in Databricks (Recommended for simplicity)
+
+The simplest approach is to ensure that all column descriptions in your Databricks Unity Catalog tables do not exceed 512 characters.
+
+**Steps:**
+
+1. Review column comments in your Databricks tables.
+2. Identify any comments that exceed 512 characters.
+3. Edit those comments to be 512 characters or fewer.
+4. Save the changes in Databricks.
+5. Retry the import in Tabular Editor.
+
+**Benefits:**
+- Simple to implement
+- No configuration changes required
+- Works across all tools connecting to Databricks
+
+**Trade-offs:**
+- Requires modification of source metadata
+- May lose information if descriptions are truncated
+- Not suitable if longer descriptions are required
+
+### Option 2: Increase the MaxCommentLen parameter in Simba Driver
+
+If you need to preserve column comments longer than 512 characters, you can configure the Simba Spark ODBC Driver to accommodate larger comments.
+
+> [!NOTE]
+> Before proceeding, ensure you have the latest version of the Simba Spark ODBC Driver for Databricks installed. You can download it from the [Microsoft Azure Databricks ODBC download page](https://learn.microsoft.com/azure/databricks/integrations/odbc/download).
+
+**Steps:**
+
+1. **Locate the Simba Spark ODBC Driver installation folder.**
+
+   The default installation location for the 64-bit driver is:
+   ```
+   C:\Program Files\Simba Spark ODBC Driver\
+   ```
+
+   If you installed the driver to a custom location, navigate to that folder instead.
+
+2. **Create or edit the microsoft.sparkodbc.ini file.**
+
+   In the driver installation folder, create a new file named **microsoft.sparkodbc.ini** (if it doesn't already exist).
+
+   > [!NOTE]
+   > The Simba Spark ODBC Driver installer does not create this .ini file by default, so you will likely need to create it manually.
+
+3. **Add the MaxCommentLen configuration.**
+
+   Open the **microsoft.sparkodbc.ini** file in a text editor (such as Notepad) and add the following content:
+
+   ```ini
+   [Driver]
+   MaxCommentLen=2048
+   ```
+
+   Adjust the value (2048 in this example) to accommodate the maximum comment length you need.
+
+4. **Save the file.**
+
+   Ensure the file is saved as **microsoft.sparkodbc.ini** (not microsoft.sparkodbc.ini.txt) in the driver installation folder.
+
+5. **Restart Tabular Editor.**
+
+   Close all instances of Tabular Editor and reopen the application for the configuration change to take effect.
+
+6. **Retry the import.**
+
+   Use the Import Table Wizard again to import your Databricks tables. The connection should now succeed with the increased comment length limit.
+
+**Benefits:**
+- Preserves full column descriptions
+- No need to modify source metadata
+- Applies to all Databricks connections using this driver
+
+**Trade-offs:**
+- Requires file system access to the driver installation folder
+- Configuration file must be created manually
+- Changes apply machine-wide, affecting other applications using the same driver
+
+---
+
+## Step-by-Step Example: Creating the microsoft.sparkodbc.ini File
+
+If you've never created an .ini file before, follow these detailed steps:
+
+1. **Open Notepad** (or your preferred text editor).
+
+2. **Type the following content:**
+
+   ```ini
+   [Driver]
+   MaxCommentLen=2048
+   ```
+
+3. **Save the file:**
+   - Click **File > Save As**
+   - Navigate to `C:\Program Files\Simba Spark ODBC Driver\`
+   - In the **Save as type** dropdown, select **All Files (*.*)** (important!)
+   - In the **File name** field, type exactly: **microsoft.sparkodbc.ini**
+   - Click **Save**
+
+   > [!IMPORTANT]
+   > Make sure to select "All Files" as the file type, otherwise Notepad will save it as microsoft.sparkodbc.ini.txt, which will not work.
+
+4. **Verify the file was created correctly:**
+   - Open File Explorer and navigate to `C:\Program Files\Simba Spark ODBC Driver\`
+   - Confirm that you see a file named **microsoft.sparkodbc.ini** (not microsoft.sparkodbc.ini.txt)
+
+5. **Close and restart Tabular Editor** for the changes to take effect.
+
+---
+
+## Quick Troubleshooting Checklist
+
+- [ ] **Confirm the error message**: Verify that the connection error occurs during the Import Table Wizard when connecting to Databricks.
+- [ ] **Check column comment lengths**: Query your Databricks tables to identify any column comments exceeding 512 characters.
+- [ ] **Verify driver installation**: Confirm that the Simba Spark ODBC Driver is installed and locate its installation folder.
+- [ ] **Check .ini file location**: Ensure the **microsoft.sparkodbc.ini** file is in the correct folder (the driver installation directory, not a subdirectory).
+- [ ] **Verify file extension**: Confirm the file is named **microsoft.sparkodbc.ini** and not **microsoft.sparkodbc.ini.txt**.
+- [ ] **Restart Tabular Editor**: Configuration changes only take effect after restarting the application.
+
+---
+
+## Prevention Best Practices
+
+1. **Establish comment length guidelines**: If you're managing Databricks metadata, consider establishing guidelines to keep column comments under 512 characters for maximum compatibility.
+
+2. **Test imports early**: When setting up a new Databricks environment, test table imports in Tabular Editor early in the development process to identify any metadata issues.
+
+3. **Document driver configuration**: If you modify the **microsoft.sparkodbc.ini** file, document the change in your team's runbook so others are aware of the customization.
+
+4. **Review after driver updates**: When updating the Simba Spark ODBC Driver, verify that your **microsoft.sparkodbc.ini** file is still present, as driver updates may overwrite or remove custom configuration files.
+
+---
+
+## Additional Resources
+
+- **[Databricks Knowledge Base - Unity Catalog Metadata Error](https://kb.databricks.com/unity-catalog/error-when-trying-to-load-a-dataset-after-integrating-unity-catalog-metadata-with-power-bi)**: Official Databricks documentation covering this issue and the MaxCommentLen parameter.
+- **[Simba Spark ODBC Driver for Azure Databricks](https://learn.microsoft.com/azure/databricks/integrations/odbc/download)**: Download the latest version of the Simba Spark ODBC Driver for Databricks.
+- **[Import Table Wizard](xref:importing-tables)**: Learn more about using the Import Table Wizard in Tabular Editor.
+
+---
+
+## Still Need Help?
+
+If the steps above don't resolve your issue:
+
+1. **Verify ODBC driver version**: Ensure you have the latest version of the Simba Spark ODBC Driver installed. You can download it from the [Microsoft Azure Databricks ODBC download page](https://learn.microsoft.com/azure/databricks/integrations/odbc/download).
+
+2. **Check ODBC Data Source configuration**: Open the Windows ODBC Data Source Administrator (odbcad32.exe) and verify that your Databricks connection is configured correctly.
+
+3. **Test with a simpler table**: Try importing a Databricks table that you know has short column comments (or no comments) to confirm the connection works in general.
+
+4. **Review ODBC driver logs**: The Simba Spark ODBC Driver can generate detailed logs. Refer to the driver documentation for instructions on enabling logging, which may provide additional diagnostic information.
+
+5. **Contact support**: Reach out to Tabular Editor support with:
+   - The full error message text
+   - Your Databricks connection details (excluding credentials)
+   - The Simba Spark ODBC Driver version
+   - Whether you have created the microsoft.sparkodbc.ini file and its contents


### PR DESCRIPTION
## Change description
Add new troubleshooting articles and expand UI documentation with window docking and shortcut entries.

### Implementation
Two new troubleshooting articles have been added covering the composite model measure formatting conflict and the Databricks ODBC driver column comment length limitation. The user interface documentation has been extended with a dedicated section explaining the two docking modes and their behavioral differences. The keyboard shortcut reference has been updated to include Ctrl+Tab for switching between in-focus windows.

