### PR TITLE
Added regex fail detection to build script. This will fail the pipeline if any warnings happen. 

### DIFF
--- a/build-docs.py
+++ b/build-docs.py
@@ -23,25 +23,61 @@ Options:
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 
-def run_command(cmd: list[str], description: str, check: bool = True) -> int:
-    """Run a command and return exit code."""
+_DOCFX_WARNING_RE = re.compile(r': warning ', re.IGNORECASE)
+
+
+def run_command(cmd: list[str], description: str, check: bool = True, fail_on_warnings: bool = False) -> int:
+    """Run a command and return exit code.
+
+    If fail_on_warnings=True, streams output line-by-line, counts DocFX warning
+    diagnostics (lines matching ': warning '), and returns exit code 1 if any
+    are found — even when the process itself exits 0.
+    """
     print(f"\n{'='*60}")
     print(f"  {description}")
     print(f"{'='*60}")
     print(f"Running: {' '.join(cmd)}\n")
-    
+
+    if fail_on_warnings:
+        warning_count = 0
+        process = subprocess.Popen(
+            cmd,
+            shell=(os.name == 'nt'),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding='utf-8',
+            errors='replace'
+        )
+        for line in process.stdout:
+            print(line, end='', flush=True)
+            if _DOCFX_WARNING_RE.search(line):
+                warning_count += 1
+        process.wait()
+
+        if check and process.returncode != 0:
+            print(f"Error: Command failed with exit code {process.returncode}")
+            return process.returncode
+
+        if warning_count > 0:
+            print(f"\nError: DocFX produced {warning_count} warning(s). Failing build.")
+            return 1
+
+        return process.returncode
+
     result = subprocess.run(cmd, shell=(os.name == 'nt'))
-    
+
     if check and result.returncode != 0:
         print(f"Error: Command failed with exit code {result.returncode}")
         return result.returncode
-    
+
     return result.returncode
 
 
@@ -110,10 +146,11 @@ def build_language(lang: str, sync: bool = False) -> int:
     if result != 0:
         return result
     
-    # Build the documentation
+    # Build the documentation — fail if DocFX emits any warnings
     return run_command(
         ["docfx", config_path],
-        f"Building {lang} documentation"
+        f"Building {lang} documentation",
+        fail_on_warnings=True
     )
 
 


### PR DESCRIPTION
This is a follow up to a discussion that we had before my vacation. 

This modification to the script will now fail the build pipeline if any warnings are detected. This is to alert the developers to issues that are not caught initially.  See issue as an example #309