### PR TITLE
docs(cli): rename --output to --output-format, --format to --serialization

### DIFF
--- a/content/features/te-cli/te-cli-auth.md
+++ b/content/features/te-cli/te-cli-auth.md
@@ -66,7 +66,7 @@ Display the current authentication state without opening a browser:
 
 ```bash
 te auth status
-te auth status --output json
+te auth status --output-format json
 ```
 
 Exit code is `0` when a valid session exists, `1` when not logged in or expired.

--- a/content/features/te-cli/te-cli-automation.md
+++ b/content/features/te-cli/te-cli-automation.md
@@ -20,23 +20,24 @@ The Tabular Editor CLI is designed as a composable building block. Every command
 
 ## Structured output
 
-Use `--output` to switch any command between text (human-readable) and machine-readable formats:
+Use `--output-format` to switch any command between text (human-readable) and machine-readable formats:
 
 | Format | Use for | Notes |
 | -- | -- | -- |
-| `auto` (default) | General use | Text for TTY, JSON when stdout is piped or redirected. |
-| `text` | Force text output | Useful when you want text in a CI log. |
-| `json` | Programmatic consumers | Always valid JSON to stdout; errors and warnings go to stderr as separate JSON objects. |
-| `csv` | Tabular results (`query`, `bpa`, `vertipaq`) | RFC 4180 escaping. |
+| `text` (default) | Human-readable use | Plain text on stdout regardless of whether the stream is a TTY or piped. |
+| `json` | Programmatic consumers | Always valid JSON to stdout. Use `--error-format json` if you also want machine-readable errors on stderr. |
+| `csv` | Tabular results (`query`, `bpa run`, `bpa rules`, `vertipaq`, `validate`, `test`, `refresh`, `profile list`, `session list`, `find`, `replace`, `get`, `ls`) | RFC 4180 escaping. |
+| `tmsl` (alias `bim`) | Whole-object TMSL/BIM serialization | Accepted by `te get` and `te ls`. |
+| `tmdl` | Whole-object TMDL serialization | Accepted by `te get` only (single object). |
 
 ```bash
-te ls --output json
-te query -q "EVALUATE VALUES('Date'[Year])" --output csv
-te bpa run --output json
+te ls --output-format json
+te query -q "EVALUATE VALUES('Date'[Year])" --output-format csv
+te bpa run --output-format json
 ```
 
-> [!TIP]
-> When stdout is piped, `auto` already emits JSON. Explicit `--output json` is only necessary when you want JSON on a TTY, or when a consumer expects it regardless of how the command is invoked.
+> [!NOTE]
+> `--output-format` and `--error-format` are independent. Setting `--output-format json` does *not* switch stderr to JSON; pass `--error-format json` for that. There is no automatic format switching when stdout is redirected - the default is always `text` unless you ask otherwise.
 
 ## Non-interactive mode
 
@@ -61,8 +62,8 @@ Combine exit codes with `--ci <vsts\|github>` annotations and `--trx <file>` to 
 Errors, warnings, and the preview banner are written to **stderr**; structured data is written to **stdout**. This means you can pipe JSON safely without it being contaminated by progress indicators or diagnostic messages:
 
 ```bash
-te ls --output json | jq '.[] | .name'
-te vertipaq --output json > stats.json
+te ls --output-format json | jq '.[] | .name'
+te vertipaq --output-format json > stats.json
 ```
 
 ## Python
@@ -79,7 +80,7 @@ def query(server: str, database: str, dax: str) -> list[dict]:
          "-s", server,
          "-d", database,
          "-q", dax,
-         "--output", "json",
+         "--output-format", "json",
          "--non-interactive"],
         check=True,
         capture_output=True,
@@ -101,7 +102,7 @@ import subprocess
 result = subprocess.run(
     ["te", "deploy", "./model",
      "-s", "Finance", "-d", "Revenue",
-     "--output", "json", "--non-interactive", "--force"],
+     "--output-format", "json", "--non-interactive", "--force"],
     capture_output=True, text=True,
 )
 
@@ -118,7 +119,7 @@ if result.returncode != 0:
 PowerShell handles JSON natively. Because `te` is a normal console binary, there is no need for the `start /wait` dance required by `TabularEditor.exe`:
 
 ```powershell
-$rows = te query -s Finance -d Revenue -q "EVALUATE TOPN(10, 'Sales')" --output json --non-interactive
+$rows = te query -s Finance -d Revenue -q "EVALUATE TOPN(10, 'Sales')" --output-format json --non-interactive
   | ConvertFrom-Json
 
 $rows | Format-Table
@@ -144,18 +145,18 @@ te deploy ./model `
 
 ## Bash
 
-Compose commands with pipes and `jq`. The CLI's text output is colorized for humans, but switching to `--output json` gives you a clean shape to work with:
+Compose commands with pipes and `jq`. The CLI's text output is colorized for humans, but switching to `--output-format json` gives you a clean shape to work with:
 
 ```bash
 # Count measures per table
-te ls --type measure --output json \
+te ls --type measure --output-format json \
   | jq -r '.[] | .table' \
   | sort | uniq -c | sort -rn
 ```
 
 ```bash
 # Fail the shell script if BPA finds any errors
-te bpa run --fail-on error --output json > bpa.json \
+te bpa run --fail-on error --output-format json > bpa.json \
   || { echo "BPA gate failed"; jq '.violations' bpa.json; exit 1; }
 ```
 

--- a/content/features/te-cli/te-cli-cicd.md
+++ b/content/features/te-cli/te-cli-cicd.md
@@ -33,7 +33,7 @@ The Tabular Editor CLI is designed for unattended execution in continuous integr
 - **`--force`** on mutating commands (`te deploy`, `te refresh`) skips confirmation prompts.
 - **`--ci vsts` / `--ci github`.** Emit native pipeline annotations to stderr.
 - **`--trx <file>`.** Produce VSTEST results consumable by Azure DevOps test publishing.
-- **Structured errors.** `--output json` emits `{"error": "...", "hint": "..."}` to stderr so pipeline steps can fail with a useful message.
+- **Structured errors.** `--output-format json` emits `{"error": "...", "hint": "..."}` to stderr so pipeline steps can fail with a useful message.
 
 ## Adding the CLI to your repo
 

--- a/content/features/te-cli/te-cli-commands.md
+++ b/content/features/te-cli/te-cli-commands.md
@@ -127,7 +127,8 @@ These flags are available on every command and sit before or after the subcomman
 | `-d, --database <name>` | Semantic model name on the workspace. |
 | `--local` | Connect to a locally running Power BI Desktop instance (Windows only). |
 | `--auth <method>` | Auth method: `auto`, `interactive`, `spn`, `env`, `managed-identity` (default: `auto`). |
-| `--output <format>` | Output format: `auto`, `text`, `json`, `csv`, `tmsl` (alias `bim`), `tmdl` (default: `auto` - text for TTY, JSON for pipes). `tmsl`/`tmdl` are accepted by `te get` and `te ls` for whole-object serialization. |
+| `--output-format <format>` | Stdout format: `text` (default), `json`, `csv`, `tmsl` (alias `bim`), `tmdl`. `csv` is honored by commands that emit tabular data; `tmsl`/`tmdl` only by `te get` and `te ls` for whole-object serialization. Commands reject formats they don't support. |
+| `--error-format <format>` | Stderr format for errors, warnings, and hints: `text` (default) or `json`. Other values fall back to text. Independent of `--output-format`, so you can pair JSON stdout with plain-text errors (or vice versa). |
 | `--recent [N]` | Use a recently used model. No value = interactive picker; `N` = Nth most recent (1 = last used). |
 | `--non-interactive` | Disable all interactive prompts. Fail with an actionable error if required input is missing. |
 | `--debug` | Enable debug logging to stderr (connection strings, auth flow, timing). |
@@ -151,7 +152,7 @@ te load -s MyWorkspace -d MyModel          # Remote workspace
 Save a model to disk. Use it to write a remote workspace model to local files, convert formats, or persist edits back to the source.
 
 - `-o, --output-path <path>` - target file or folder. **Optional** - when omitted, `te save` writes back to the source location, preserving the original format.
-- `--format <fmt>` - `tmdl`, `bim`, `te-folder`, `pbip`, `database.json`. Defaults to inferring from the loaded model (BIM source → BIM, TMDL `SemanticModel/` → TMDL under `definition/`).
+- `--serialization <fmt>` - `tmdl`, `bim`, `te-folder`, `pbip`, `database.json`. Defaults to inferring from the loaded model (BIM source → BIM, TMDL `SemanticModel/` → TMDL under `definition/`).
 - `--force` - skip validation and overwrite existing output. Some refusals (ambiguous containers, multi-`SemanticModel` project roots) fire even under `--force`.
 - `--skip-bpa` / `--fix-bpa` - bypass or auto-fix the BPA gate.
 - `--bpa-rules <path>` - repeatable; override `bpa.rules` from your CLI config for this single save. Built-in rules still apply unless `bpa.builtInRules` is `false`.
@@ -161,7 +162,7 @@ Save a model to disk. Use it to write a remote workspace model to local files, c
 ```bash
 te save                                    # Save back to source (no -o needed)
 te save ./model.bim -o ./tmdl-out          # Convert BIM to TMDL
-te save -o ./project --format pbip         # Save as a PBIP project
+te save -o ./project --serialization pbip         # Save as a PBIP project
 te save -o ./out -s my-workspace -d my-model --skip-validation   # Fast download
 ```
 
@@ -261,7 +262,7 @@ List objects with filesystem-like navigation. Takes a `<path-filter>` argument s
 - `--type <kind>` - narrow to one object kind (`table`, `measure`, `column`, `hierarchy`, `partition`, `relationship`, `role`, `perspective`, `culture`). With no `<path-filter>` this is equivalent to typing the matching container keyword.
 - `--paths-only` - emit one object path per line, suitable for piping to `xargs`, `te get`, or `te set`.
 - `--no-multiline` - collapse multi-line cells (typically DAX or M expressions) to a single line and truncate, so rows stay scannable in wide tables. Text output only; JSON/CSV/TMSL output is unaffected.
-- `--output tmsl` (alias `bim`) - emit the matching objects as a TMSL/BIM script. Useful for `te ls Tables --output bim > tables.json`. `--output tmdl` is not supported by `ls` (TMDL is single-object only - use `te get`).
+- `--output-format tmsl` (alias `bim`) - emit the matching objects as a TMSL/BIM script. Useful for `te ls Tables --output-format bim > tables.json`. `--output-format tmdl` is not supported by `ls` (TMDL is single-object only - use `te get`).
 
 ```bash
 te ls                                     # All tables in the model
@@ -276,7 +277,7 @@ te ls "'Net Sales'/'Sales Amount'"        # Quote names containing spaces
 te ls Measures --paths-only               # One Table/Measure per line for piping
 te ls --type measure                      # Same as `te ls Measures`
 te ls Measures --no-multiline             # Wide table with column dividers, single-line DAX
-te ls Tables --output bim > tables.json   # All tables emitted as TMSL/BIM
+te ls Tables --output-format bim > tables.json   # All tables emitted as TMSL/BIM
 ```
 
 ### get
@@ -285,8 +286,8 @@ Get properties of a model object. Takes a `<path>`.
 
 - `-q, --query <property>` - fetch a single property (e.g. `expression`, `formatString`).
 - `-t, --type <kind>` - disambiguate when the path matches multiple table-children (e.g. a column and a hierarchy with the same name). Values: `Measure`, `Column`, `CalculatedColumn`, `Hierarchy`, `Calendar`, `Partition`, `CalculationItem`.
-- `--output tmsl` (alias `bim`) - emit the resolved object as TMSL/BIM JSON.
-- `--output tmdl` - emit the resolved object as TMDL (named objects only).
+- `--output-format tmsl` (alias `bim`) - emit the resolved object as TMSL/BIM JSON.
+- `--output-format tmdl` - emit the resolved object as TMDL (named objects only).
 
 `te get` and `te ls` share a single descriptor catalog, so every property surfaces the same way across formats - the text table, JSON, and CSV all see the same set, and adding a new property to the model exposes it everywhere.
 
@@ -296,8 +297,8 @@ te get "'Sales'[Amount]"                         # DAX form: same as Sales/Amoun
 te get "[Total Sales]"                           # Lone-bracket: model-wide measure-or-column
 te get "'Net Sales'[Sales Amount]" -q expression # DAX form with spaced names
 te get "Sales/Revenue/KPI"                       # KPI sub-object of a measure
-te get Sales --output tmdl                       # Emit the table as TMDL
-te get Sales --output bim                        # Emit the table as TMSL/BIM
+te get Sales --output-format tmdl                       # Emit the table as TMDL
+te get Sales --output-format bim                        # Emit the table as TMSL/BIM
 te get Model -q description
 ```
 
@@ -476,7 +477,7 @@ te format --lang m --save                                  # Format M
 Execute a DAX query against a deployed model.
 
 - `-q, --query <dax>` - inline query.
-- `-f, --file <file.dax>` - query from file.
+- `--file <file.dax>` - query from file.
 - `--limit <N>` - default 100.
 - `-o, --output-file <path>` - write results to file (`.csv`, `.tsv`, `.json`, `.dax`).
 - `--trace`, `--cold`, `--plan`, `--runs <N>` - performance tracing and benchmarking.
@@ -484,7 +485,7 @@ Execute a DAX query against a deployed model.
 
 ```bash
 te query -q "EVALUATE TOPN(5, 'Sales')" -s my-ws -d my-model
-te query -f query.dax --output json
+te query --file query.dax --output-format json
 ```
 
 ### script
@@ -493,7 +494,7 @@ Execute one or more C# scripts against a semantic model. The CLI uses the same s
 
 - `-S, --script <file>` - `.cs` / `.csx` file (repeatable).
 - `-e, --expression <code>` - inline C# (use `-` for stdin).
-- `--save` / `--save-to` / `--format`.
+- `--save` / `--save-to` / `--serialization`.
 - `--dry-run`, `--timeout <seconds>`.
 
 ```bash
@@ -689,7 +690,7 @@ Reference guide showing how legacy Tabular Editor 2 CLI flags map to the new CLI
 ```bash
 te migrate                   # Full flag mapping table
 te migrate -A                # Look up a single TE2 flag
-te migrate --output json     # Machine-readable mapping
+te migrate --output-format json     # Machine-readable mapping
 ```
 
 ## Shell

--- a/content/features/te-cli/te-cli-config.md
+++ b/content/features/te-cli/te-cli-config.md
@@ -43,14 +43,14 @@ te config init --force     # Overwrite existing config
 
 ```bash
 te config show                         # Display all settings
-te config show --output json           # Machine-readable
+te config show --output-format json           # Machine-readable
 te config paths                        # Show resolved macros and BPA rule paths
 ```
 
 `te config paths` resolves the files the CLI will actually use for macros and BPA rules - useful when debugging missing data files. The output shows two rows: `macros` (the resolved macros file path or `[not set]`) and `bpa.rules` (the first existing BPA rules file resolved by the path resolver, or `[not set]`).
 
 > [!NOTE]
-> `te config paths` emits `null` fields explicitly in `--output json` mode (e.g., `{"macros": null, "bpa": {"rules": null}}`). Reporting resolution outcomes is the command's whole purpose, so `null` is a meaningful "tried but resolved to nothing" answer. `te config show --output json` strips null fields by default, so consumers should parse it tolerantly.
+> `te config paths` emits `null` fields explicitly in `--output-format json` mode (e.g., `{"macros": null, "bpa": {"rules": null}}`). Reporting resolution outcomes is the command's whole purpose, so `null` is a meaningful "tried but resolved to nothing" answer. `te config show --output-format json` strips null fields by default, so consumers should parse it tolerantly.
 
 ## Setting values
 

--- a/content/features/te-cli/te-cli-limitations.md
+++ b/content/features/te-cli/te-cli-limitations.md
@@ -63,7 +63,7 @@ The CLI runs C# scripts (`te script`) against the same `Model` object you use in
 
 | Limitation | Notes / Workaround |
 | -- | -- |
-| **`--format` cannot combine a serialization with a PBIP container** | The `--format` option on [`te save`](xref:te-cli-commands#save) treats `bim`, `tmdl`, `te-folder`, and `pbip` as mutually exclusive, so you cannot currently produce a PBIP container around a TMSL-serialized (`.bim`) model. Save TMDL inside PBIP, or save `.bim` outside a PBIP wrapper. |
+| **`--serialization` cannot combine a serialization with a PBIP container** | The `--serialization` option on [`te save`](xref:te-cli-commands#save) treats `bim`, `tmdl`, `te-folder`, and `pbip` as mutually exclusive, so you cannot currently produce a PBIP container around a TMSL-serialized (`.bim`) model. Save TMDL inside PBIP, or save `.bim` outside a PBIP wrapper. |
 
 ## Authentication
 

--- a/content/features/te-cli/te-cli-migrate.md
+++ b/content/features/te-cli/te-cli-migrate.md
@@ -45,7 +45,7 @@ Use `te migrate` as a live reference for how TE2 flags map to the new CLI. It pr
 ```bash
 te migrate                   # Full flag mapping table
 te migrate -A                # Look up a single flag
-te migrate --output json     # Machine-readable mapping
+te migrate --output-format json     # Machine-readable mapping
 ```
 
 Prefer `te migrate` over this page when you need the current mapping - it reflects the CLI version you have installed.
@@ -62,9 +62,9 @@ A non-exhaustive summary of the most commonly used flags. Run `te migrate` for t
 | `-S` / `-SCRIPT` | `te script -s <file.csx>` or `-e "code"` | Supports multiple scripts, inline code, and stdin. |
 | `-A` / `-ANALYZE` | `te bpa run --rules <file-or-url>` | Supports `--fail-on`, `--fix`, multiple rule files. |
 | `-AX` / `-ANALYZEX` | `te bpa run --rules <file>` (without `--model-rules`) | Excluding model-embedded rules is the new default. |
-| `-B` / `-BIM` | `te save <model> -o <file.bim> --format bim` | |
-| `-F` / `-FOLDER` | `te save <model> -o <dir> --format te-folder` | After `-D`, TE2's `-F` means `-FULL` - see `--deploy-full`. |
-| `-TMDL` | `te save <model> -o <dir> --format tmdl` | TMDL is the default save format. |
+| `-B` / `-BIM` | `te save <model> -o <file.bim> --serialization bim` | |
+| `-F` / `-FOLDER` | `te save <model> -o <dir> --serialization te-folder` | After `-D`, TE2's `-F` means `-FULL` - see `--deploy-full`. |
+| `-TMDL` | `te save <model> -o <dir> --serialization tmdl` | TMDL is the default save format. |
 | `-D` / `-DEPLOY` | `te deploy <server> <database> <model>` | Separate command with named options. |
 | `-O` / `-OVERWRITE` | (default) or `--create-only` to opt out | Overwrite is the default in the new CLI. |
 | `-C` / `-CONNECTIONS` | `te deploy --deploy-connections` | |
@@ -99,7 +99,7 @@ The recommended path from a TE2-based pipeline to the new CLI:
 
 - **BPA gate on deploy.** `te deploy` now runs BPA as a pre-flight gate by default. Use `--skip-bpa` to preserve the old behavior, or `--fix-bpa` to auto-fix violations before deploy. See @te-cli-config.
 - **Interactive confirmation on deploy.** `te deploy` prompts for confirmation by default (with `n` as the safe default answer). CI pipelines must pass `--force`.
-- **Structured output.** Every command supports `--output json` for machine-readable output - see @te-cli-automation.
+- **Structured output.** Every command supports `--output-format json` for machine-readable output - see @te-cli-automation.
 - **No `start /wait` needed.** The new CLI is a regular console binary; invoke it directly in shell scripts, PowerShell, and CI tasks.
 - **Cross-platform.** The CLI runs on Windows, macOS, and Linux. Local SSAS and Power BI Desktop connections remain Windows-only.
 


### PR DESCRIPTION
- Replace --output <fmt> with --output-format <fmt> across all te-cli pages.
- Rename save-format --format to --serialization on save/init/add/rm/mv/set/ replace/bpa run/macro/script examples.
- Add --error-format to the global options table for independent stderr formatting.
- Drop the Auto-mode language: the default is now plain text regardless of TTY, with --output-format json the explicit opt-in.
- Drop the -f short alias for te query --file (no -f aliases anywhere in the CLI).