### PR TITLE
Fix Warnings in English build

### DIFF
--- a/build-docs.py
+++ b/build-docs.py
@@ -155,11 +155,13 @@ def build_language(lang: str, sync: bool = False) -> int:
     if result != 0:
         return result
     
-    # Build the documentation — fail if DocFX emits any warnings
+    # Build the documentation — fail on DocFX warnings only for English (the
+    # authored source). Localized content is Crowdin-managed and may carry
+    # translation warnings that must not block deployment.
     return run_command(
         ["docfx", config_path],
         f"Building {lang} documentation",
-        fail_on_warnings=True
+        fail_on_warnings=(lang == "en")
     )
 
 

--- a/content/features/te-cli/te-cli-auth.md
+++ b/content/features/te-cli/te-cli-auth.md
@@ -130,7 +130,7 @@ te connect Finance "Revenue Model" -w ./revenue-model
 te connect ./revenue-model -w Finance "Revenue Model"
 ```
 
-Save order is always **local first, then remote**, so the on-disk copy reflects the latest user change even if the server push fails. See @te-cli-commands#workspace-mode-w--workspace for `--workspace-format`, overwrite semantics, and clearing the mirror.
+Save order is always **local first, then remote**, so the on-disk copy reflects the latest user change even if the server push fails. See @te-cli-commands#workspace-mode--w----workspace for `--workspace-format`, overwrite semantics, and clearing the mirror.
 
 ## Connecting to different clouds
 

--- a/content/features/te-cli/te-cli.md
+++ b/content/features/te-cli/te-cli.md
@@ -54,7 +54,7 @@ See @te-cli-commands for a full command reference with syntax, options, and exam
 | [Execution](xref:te-cli-commands#execution) | Run DAX queries, C# scripts, macros | [`te query`](xref:te-cli-commands#query), [`te script`](xref:te-cli-commands#script), [`te macro`](xref:te-cli-commands#macro) |
 | [Deployment & Refresh](xref:te-cli-commands#deployment-and-refresh) | Deploy to workspace, trigger refresh, incremental refresh | [`te deploy`](xref:te-cli-commands#deploy), [`te refresh`](xref:te-cli-commands#refresh), [`te incremental-refresh`](xref:te-cli-commands#incremental-refresh) |
 | [Testing](xref:te-cli-commands#testing) | Assertion tests, snapshots, A/B comparison | [`te test run`](xref:te-cli-commands#test-run) |
-| [Connection & Authentication](xref:te-cli-commands#connection-and-auth) | Connect to workspaces, manage authentication and profiles | [`te connect`](xref:te-cli-commands#connect), [`te auth`](xref:te-cli-commands#auth-login--status--logout), [`te profile`](xref:te-cli-commands#profile-list--show--set--remove) |
+| [Connection & Authentication](xref:te-cli-commands#connection-and-authentication) | Connect to workspaces, manage authentication and profiles | [`te connect`](xref:te-cli-commands#connect), [`te auth`](xref:te-cli-commands#auth-login--status--logout), [`te profile`](xref:te-cli-commands#profile-list--show--set--remove) |
 | [Configuration](xref:te-cli-commands#configuration) | Settings and licensing | [`te config`](xref:te-cli-commands#config-show--paths--init--set) |
 | [Shell](xref:te-cli-commands#shell) | Interactive mode, shell completions | [`te interactive`](xref:te-cli-commands#interactive), [`te completion`](xref:te-cli-commands#completion) |
 

--- a/content/references/release-history.md
+++ b/content/references/release-history.md
@@ -4,6 +4,10 @@ title: Full release history
 ---
 # Full release history
 
+- 2026-04-17 **Tabular Editor 3.26.1** (*[Release notes](release-notes/3_26_1.md)*)
+  - .NET 8 installer (.exe): [x64](https://cdn.tabulareditor.com/files/TabularEditor.3.26.1.Installer.x64.Net8.exe), [ARM64](https://cdn.tabulareditor.com/files/TabularEditor.3.26.1.Installer.ARM64.Net8.exe)
+  - .NET 8 portable (.zip): [x64](https://cdn.tabulareditor.com/files/TabularEditor.3.26.1.x64.Net8.zip), [ARM64](https://cdn.tabulareditor.com/files/TabularEditor.3.26.1.ARM64.Net8.zip)
+  - .NET 8 installer (.msi): [x64](https://cdn.tabulareditor.com/files/TabularEditor.3.26.1.x64.Net8.msi), [ARM64](https://cdn.tabulareditor.com/files/TabularEditor.3.26.1.ARM64.Net8.msi)
 - 2026-03-25 **Tabular Editor 3.26.0** (*[Release notes](release-notes/3_26_0.md)*)
   - .NET 8 installer (.exe): [x64](https://cdn.tabulareditor.com/files/TabularEditor.3.26.0.Installer.x64.Net8.exe), [ARM64](https://cdn.tabulareditor.com/files/TabularEditor.3.26.0.Installer.ARM64.Net8.exe)
   - .NET 8 portable (.zip): [x64](https://cdn.tabulareditor.com/files/TabularEditor.3.26.0.x64.Net8.zip), [ARM64](https://cdn.tabulareditor.com/files/TabularEditor.3.26.0.ARM64.Net8.zip)


### PR DESCRIPTION
Fix existing warnings in English build.
Only fail build when there are warnings in the English language site - other languages should not fail as they are handled in CrowdIn.
Update release history page. 