### PR TITLE
docs(cli): clarify -s resolution and document on-prem SSAS deploy

### DIFF
--- a/content/features/te-cli/te-cli-commands.md
+++ b/content/features/te-cli/te-cli-commands.md
@@ -315,13 +315,6 @@ Move or rename a model object. Both source and destination are `<path>` argument
 - `--serialization <fmt>` - override the serialization when saving (`tmdl`, `bim` (alias `tmsl`), `database.json`).
 - `--force` - save even if the mutation introduces DAX validation errors.
 
-`te mv` accepts:
-
-- `-t, --type <kind>` - disambiguate when the source path matches multiple object kinds (e.g., a column and a hierarchy with the same name).
-- `--save` / `--save-to <path>` - persist the change.
-- `--serialization <fmt>` - override the serialization when saving (`tmdl`, `bim` (alias `tmsl`), `database.json`).
-- `--force` - save even if the mutation introduces DAX validation errors.
-
 ```bash
 te move Sales/Revenue Finance/Revenue --save                # Move measure to another table
 te move Sales/Revenue Sales/TotalRevenue --save             # Rename measure

--- a/content/features/te-cli/te-cli-commands.md
+++ b/content/features/te-cli/te-cli-commands.md
@@ -144,7 +144,7 @@ These flags are available on every command and can be used before or after the s
 | Option | Description |
 | -- | -- |
 | `-m, --model <path>` | Path to semantic model (TMDL folder, `.bim` file, `database.json` folder, or `.SemanticModel` folder). |
-| `-s, --server <endpoint>` | Workspace name or endpoint (e.g., `MyWorkspace`, `powerbi://...`, `asazure://...`, `localhost`). |
+| `-s, --server <endpoint>` | Analysis Services endpoint or Power BI workspace. A server name/FQDN (`MY.SERVER.COM`), IP address (`192.168.1.1`), `host:port`, `localhost`, `SERVER\INSTANCE`, `asazure://...`, or an MSOLAP connection string connects directly to Analysis Services / AAS. A bare single-token name (`MyWorkspace`), a Fabric `Name.Workspace[/Model.SemanticModel]` path, or a `powerbi://...` URL targets a Power BI workspace. A workspace name containing a dot is indistinguishable from a server name, so it is treated as a server and the CLI prints a warning; use its `.Workspace` form or full `powerbi://` URL to target Power BI. |
 | `-d, --database <name>` | Semantic model name on the workspace. |
 | `--local` | Connect to a locally running Power BI Desktop instance (Windows only). |
 | `--auth <method>` | Auth method: `auto`, `interactive`, `spn`, `env`, `managed-identity` (default: `auto`). |
@@ -840,11 +840,11 @@ te macro run "Format DAX" --on "'Net Sales'[Sales Amount]" --save   # DAX form w
 
 ### deploy
 
-Deploy a semantic model to Power BI, Fabric, or Azure Analysis Services.
+Deploy a semantic model to Power BI, Fabric, Azure Analysis Services, or on-prem SQL Server Analysis Services.
 
 `te deploy` accepts:
 
-- `-s, --server` / `-d, --database` - target workspace and model.
+- `-s, --server` / `-d, --database` - target server/workspace and model. A server name, FQDN, IP address, or MSOLAP connection string deploys to Analysis Services (Windows Integrated auth for on-prem); a workspace name or `powerbi://...` URL deploys to Power BI. See the [global options](#global-options) table for how `-s` is interpreted.
 - `--deploy-full` - overwrite + connections + partitions + shared expressions + roles + role members.
 - `--deploy-connections`
 - `--deploy-partitions`
@@ -863,6 +863,7 @@ Deploy a semantic model to Power BI, Fabric, or Azure Analysis Services.
 
 ```bash
 te deploy ./model -s my-workspace -d my-model --force --ci github
+te deploy ./model -s MY.SERVER.COM -d my-model --force    # On-prem SSAS (Integrated auth)
 te deploy ./model --xmla script.tmsl    # Generate TMSL only
 te deploy ./model --profile staging --force
 ```

--- a/content/features/te-cli/te-cli-commands.md
+++ b/content/features/te-cli/te-cli-commands.md
@@ -315,6 +315,13 @@ Move or rename a model object. Both source and destination are `<path>` argument
 - `--serialization <fmt>` - override the serialization when saving (`tmdl`, `bim` (alias `tmsl`), `database.json`).
 - `--force` - save even if the mutation introduces DAX validation errors.
 
+`te mv` accepts:
+
+- `-t, --type <kind>` - disambiguate when the source path matches multiple object kinds (e.g., a column and a hierarchy with the same name).
+- `--save` / `--save-to <path>` - persist the change.
+- `--serialization <fmt>` - override the serialization when saving (`tmdl`, `bim` (alias `tmsl`), `database.json`).
+- `--force` - save even if the mutation introduces DAX validation errors.
+
 ```bash
 te move Sales/Revenue Finance/Revenue --save                # Move measure to another table
 te move Sales/Revenue Sales/TotalRevenue --save             # Rename measure


### PR DESCRIPTION
## Summary

Clarifies how the TE CLI interprets the `-s, --server` option and documents on-premises SQL Server Analysis Services as a `te deploy` target.

- Expanded the `-s, --server` global option description to explain when an endpoint connects directly to Analysis Services / AAS (server name/FQDN, IP, `host:port`, `localhost`, `SERVER\INSTANCE`, `asazure://...`, MSOLAP connection string) versus targeting a Power BI workspace (bare single-token name, Fabric `Name.Workspace[/Model.SemanticModel]` path, or `powerbi://...` URL).
- Noted the ambiguous case: a workspace name containing a dot is treated as a server (with a warning); use the `.Workspace` form or full `powerbi://` URL to disambiguate.
- Updated the `te deploy` section to list on-prem SSAS as a supported target and added an example using Windows Integrated auth.

## File changed

- `content/features/te-cli/te-cli-commands.md`