### PR TITLE
docs(te-cli): document interactive piped/non-interactive stdin, comments, and --no-banner/--echo/--batch/--no-batch

### DIFF
--- a/content/features/te-cli/te-cli-interactive.md
+++ b/content/features/te-cli/te-cli-interactive.md
@@ -2,7 +2,7 @@
 uid: te-cli-interactive
 title: Interactive Mode
 author: Peer Grønnerup
-updated: 2026-05-12
+updated: 2026-06-26
 applies_to:
   products:
     - product: Tabular Editor 2
@@ -83,6 +83,64 @@ These are handled by the REPL itself, not the regular command tree:
 When interactive mode is active, commands that need missing input prompt for it instead of failing. Running `auth` without a subcommand opens a picker for Login / Status / Logout; running `deploy` without `--force` shows a summary and asks for confirmation (`n` is the safe default).
 
 To disable prompts for a single command inside the session, pass `--non-interactive`.
+
+## Piped and redirected input
+
+Interactive mode also accepts piped or redirected stdin, so the same REPL can be driven from a script instead of typed by hand. Each line of input is run as a command, exactly as if you had entered it at the prompt, and the session exits when input is exhausted (or when it reaches an `exit` line).
+
+```bash
+printf "ls\nexit\n" | te interactive ./model        # bash / git-bash
+te interactive ./model < script.te                  # redirected file
+```
+
+```bat
+(echo ls & echo exit) | te interactive .\model      :: Windows cmd.exe
+```
+
+Lines that start with `#` are treated as comments and skipped, so you can annotate a script file:
+
+```
+# script.te - inspect the model, then exit
+ls tables
+ls measures
+exit
+```
+
+### Batch mode and exit codes
+
+When stdin is piped, `--batch` is the **default**: the session stops at the first command that fails and exits with a non-zero code, which makes a piped run safe to use as a build or CI step. Pass `--no-batch` to keep running the remaining lines even after a command fails. The process exit code is `0` for a clean run and non-zero when a command fails under batch mode.
+
+```bash
+# Default when piped: stop at the first failing command, exit non-zero
+printf "bpa run --fail-on error\ndeploy --force\nexit\n" | te interactive ./model
+
+# Run every line regardless of failures
+printf "bpa run --fail-on error\ndeploy --force\nexit\n" | te interactive ./model --no-batch
+```
+
+### Readable transcripts
+
+`--echo` writes each input line to stdout ahead of its output, which is handy when capturing a transcript of a piped run. Comment lines are not echoed.
+
+```bash
+printf "ls tables\nexit\n" | te interactive ./model --echo
+```
+
+### Options
+
+| Option | Description |
+| -- | -- |
+| `--no-banner` | Suppress the welcome banner. |
+| `--echo` | Echo each input line to stdout (useful for piped transcripts). |
+| `--batch` | Exit non-zero on the first failing command (default when stdin is piped). |
+| `--no-batch` | Continue after errors even when stdin is piped. |
+
+### Welcome banner vs. preview notice
+
+Two separate messages can appear at the start of a session - don't conflate them:
+
+- The **welcome banner** is the interactive splash described under [Starting a session](#starting-a-session). It is suppressed with `--no-banner`. When stdin is piped, no welcome banner is emitted in the first place, so `--no-banner` has a visible effect only in a true interactive (TTY) session.
+- The **preview-expiry notice** (`This is an early preview release ...`) is a different message. It is always written to **stderr** and is **not** affected by `--no-banner`. Suppress it with `te config set hidePreviewNotice true`.
 
 ## When to use interactive vs. non-interactive
 


### PR DESCRIPTION
## Summary

The interactive REPL (`te interactive`) gained piped / non-interactive input handling in Milestone 2. These features appear in `te interactive --help` but were undocumented. This PR documents them on the Interactive Mode page.

Targets the **`cli/pupr-milestone2-release`** branch (Milestone 2 / Public Preview docs collection), not `main`.

## What was added

A new **Piped and redirected input** section on `content/features/te-cli/te-cli-interactive.md`, covering:

- Driving the REPL from piped or redirected stdin - each line runs as a command (bash/git-bash, Windows cmd.exe, and `< script.te` forms).
- Lines starting with `#` are treated as comments and skipped.
- **Batch mode and exit codes**: `--batch` is the default when stdin is piped (stops at the first failing command and exits non-zero); `--no-batch` continues past errors. Exit code is `0` on a clean run, non-zero on failure under batch mode.
- `--echo` echoes each input line to stdout for readable transcripts (comment lines are not echoed).
- An options reference table for `--no-banner`, `--echo`, `--batch`, `--no-batch` (descriptions verbatim from `--help`).
- A **Welcome banner vs. preview notice** subsection clarifying that `--no-banner` suppresses only the interactive welcome banner (no effect when piped, since no banner is emitted), while the separate preview-expiry notice is written to stderr and suppressed via `te config set hidePreviewNotice true`.

## Verification

All documented examples and behaviors were sanity-checked against `te.exe 0.5.2.12402`, including the cmd.exe pipe form and the batch-mode exit codes.

## Notes

- English page only; the `localizedContent/es` and `/zh` copies are intentionally untouched (translations handled separately).
- Bumped the page front-matter `updated:` date.