### PR TITLE
Document CLI command aliases and interactive-mode auto-launch

### DIFF
--- a/content/features/te-cli/te-cli-commands.md
+++ b/content/features/te-cli/te-cli-commands.md
@@ -117,6 +117,29 @@ DAX bracket-suffix is rejected in filter paths; quote names containing `[` and `
 
 Misspelled segments emit a contextual error with a "did you mean" hint when the CLI can guess what you meant. Missing-parent paths fail before the leaf check, so the message points at the segment that's actually wrong. Empty containers (e.g., `te list Hierarchies` on a model without hierarchies) emit a simply "nothing here" hint rather than an error.
 
+## Command aliases
+
+Most long-form verbs also accept a short alias so existing scripts and muscle memory keep working. Every alias in the table below is real and current; canonical names are what the docs use in prose and examples.
+
+| Canonical | Aliases |
+| -- | -- |
+| `te list` | `ls` |
+| `te remove` | `rm` |
+| `te move` | `mv`, `rename` |
+| `te bpa rules list` | `ls` |
+| `te bpa rules remove` | `rm` |
+| `te config list` | `ls` |
+| `te macro list` | `ls` |
+| `te macro remove` | `rm` |
+| `te incremental-refresh remove` | `rm` |
+| `te profile list` | `ls` |
+| `te profile remove` | `rm` |
+| `te session list` | `ls` |
+| `te test list` | `ls` |
+
+> [!NOTE]
+> `te config show` is **not** an alias for `te config list` - it was removed. Update any scripts that call `te config show`.
+
 ## Global options
 
 These flags are available on every command and can be used before or after the subcommand name.
@@ -530,7 +553,7 @@ Subcommands:
 | [`enable`](#bpa-rules-enable) | Re-enable a previously disabled built-in BPA rule. |
 | `ignore <rule-id> [model]` | Add a rule to the model's ignore list. |
 | [`init`](#bpa-rules-init) | Create an empty BPA rules file at the resolved path. |
-| [`list`](#bpa-rules-list) | List BPA rules from all sources with status. |
+| [`list`](#bpa-rules-list) (alias `ls`) | List BPA rules from all sources with status. |
 | `remove <rule-id> [model]` (alias `rm`) | Remove a BPA rule. |
 | `set <rule-id> [model]` | Update a BPA rule's properties. |
 | `unignore <rule-id> [model]` | Remove a rule from the model's ignore list. |
@@ -550,7 +573,7 @@ All `te bpa rules` subcommands accept:
 
 #### bpa rules list
 
-List rules from all sources (built-in, user, model).
+List rules from all sources (built-in, user, model). (Alias: `ls`.)
 
 `te bpa rules list` accepts:
 
@@ -757,7 +780,7 @@ Subcommands:
 
 | Subcommand | Purpose |
 | -- | -- |
-| `list` | List macros. |
+| `list` (alias `ls`) | List macros. |
 | [`run <name-or-id>`](#macro-run) | Run a macro. |
 | `add <name>` | Add a macro. |
 | `set <name-or-id>` | Update macro properties. |
@@ -897,6 +920,8 @@ te test run --tag revenue
 
 ### test init / spec / use / list / snapshot / compare
 
+`te test list` also accepts the `ls` alias.
+
 Additional subcommands scaffold tests, print the assertion spec format, switch the active suite, list suites, capture snapshots, and compare models. See `te test --help` for details.
 
 ```bash
@@ -945,7 +970,7 @@ Manage cached authentication. See @te-cli-auth.
 
 ### profile list / show / set / remove
 
-Manage named connection profiles. See @te-cli-auth.
+Manage named connection profiles. (`te profile list` alias: `ls`; `te profile remove` alias: `rm`.) See @te-cli-auth.
 
 ## Configuration
 
@@ -1002,7 +1027,7 @@ Subcommands:
 | Subcommand | Purpose |
 | -- | -- |
 | `show` | Show current session details (ID, file path, active state). Default when no subcommand is given. |
-| `list` | List all session files. |
+| `list` (alias `ls`) | List all session files. |
 | `clear` | Clear active state for the current session. |
 | `prune` | Delete session files whose shell process is no longer running. |
 

--- a/content/features/te-cli/te-cli-commands.md
+++ b/content/features/te-cli/te-cli-commands.md
@@ -998,6 +998,9 @@ te migrate --output-format json     # Machine-readable mapping
 
 Start a guided REPL session with a model-aware prompt. See @te-cli-interactive.
 
+> [!TIP]
+> Running `te` in a terminal with no arguments also drops you into the REPL by default (as if you ran `te interactive`). Controlled by the `launchInteractiveMode` config key - see @te-cli-interactive#auto-launch-on-empty-invocation.
+
 `te interactive` accepts:
 
 - `<model>` - optional positional argument: start the session with a local model, `.bim` file, or `.SemanticModel` folder loaded.

--- a/content/features/te-cli/te-cli-commands.md
+++ b/content/features/te-cli/te-cli-commands.md
@@ -119,7 +119,7 @@ Misspelled segments emit a contextual error with a "did you mean" hint when the 
 
 ## Command aliases
 
-Most long-form verbs also accept a short alias so existing scripts and muscle memory keep working. Each row shows the canonical command and the equivalent short-form command it accepts as an alias.
+Most long-form verbs also accept a short alias. Each row shows the canonical command and the equivalent short-form command it accepts as an alias.
 
 | Canonical | Aliased form(s) |
 | -- | -- |

--- a/content/features/te-cli/te-cli-commands.md
+++ b/content/features/te-cli/te-cli-commands.md
@@ -119,26 +119,23 @@ Misspelled segments emit a contextual error with a "did you mean" hint when the 
 
 ## Command aliases
 
-Most long-form verbs also accept a short alias so existing scripts and muscle memory keep working. Every alias in the table below is real and current; canonical names are what the docs use in prose and examples.
+Most long-form verbs also accept a short alias so existing scripts and muscle memory keep working. Each row shows the canonical command and the equivalent short-form command it accepts as an alias.
 
-| Canonical | Aliases |
+| Canonical | Aliased form(s) |
 | -- | -- |
-| `te list` | `ls` |
-| `te remove` | `rm` |
-| `te move` | `mv`, `rename` |
-| `te bpa rules list` | `ls` |
-| `te bpa rules remove` | `rm` |
-| `te config list` | `ls` |
-| `te macro list` | `ls` |
-| `te macro remove` | `rm` |
-| `te incremental-refresh remove` | `rm` |
-| `te profile list` | `ls` |
-| `te profile remove` | `rm` |
-| `te session list` | `ls` |
-| `te test list` | `ls` |
-
-> [!NOTE]
-> `te config show` is **not** an alias for `te config list` - it was removed. Update any scripts that call `te config show`.
+| `te list` | `te ls` |
+| `te remove` | `te rm` |
+| `te move` | `te mv`, `te rename` |
+| `te bpa rules list` | `te bpa rules ls` |
+| `te bpa rules remove` | `te bpa rules rm` |
+| `te config list` | `te config ls` |
+| `te macro list` | `te macro ls` |
+| `te macro remove` | `te macro rm` |
+| `te incremental-refresh remove` | `te incremental-refresh rm` |
+| `te profile list` | `te profile ls` |
+| `te profile remove` | `te profile rm` |
+| `te session list` | `te session ls` |
+| `te test list` | `te test ls` |
 
 ## Global options
 

--- a/content/features/te-cli/te-cli-config.md
+++ b/content/features/te-cli/te-cli-config.md
@@ -94,6 +94,7 @@ The complete JSON config schema with all keys at their default values. Use this 
   },
 
   "interactiveEditMode": "stage",
+  "launchInteractiveMode": "auto",
 
   "formatOptions": {
     "useSemicolons": false,
@@ -152,6 +153,7 @@ All BPA-related settings live under the `bpa` object and are addressed via dotte
 | `bpa.disabledBuiltInRuleIds` | `null` | IDs of individual built-in rules to exclude from the gate. Mutated by `te bpa rules disable <id>` / `te bpa rules enable <id>` - prefer those over editing the array directly. |
 | `vertipaqOnRefresh` | `false` | After a successful refresh (`full`, `dataonly`, `automatic`, or `add`), automatically run VertiPaq analysis to show storage stats for the refreshed tables. Useful for catching unexpected cardinality or memory regressions immediately. |
 | `interactiveEditMode` | `stage` | Default behavior for in-memory mutations inside `te interactive`. `stage` keeps mutations in memory until `save` is invoked (safest); `save` writes to source after every mutating command (use with care on remote sources - every `set` triggers an XMLA write); `revert` discards mutations after each command unless `--save` or `--stage` was passed. Per-command `--save` / `--revert` / `--stage` flags always override. |
+| `launchInteractiveMode` | `auto` | Whether running `te` in a terminal with no arguments launches the interactive REPL. `auto` (default) launches the REPL only when all three streams (stdin, stdout, stderr) are attached to a TTY, so scripts and CI pipelines fall through to normal parse. `always` launches the REPL regardless of redirection. `never` disables the auto-launch entirely, restoring the traditional help-on-empty behavior. The global `--non-interactive` flag forces `never` for a single invocation. Can also be set for one invocation via the `TE_INTERACTIVE` environment variable. |
 | `disableTelemetry` | `false` | Opt out of anonymous usage telemetry. The CLI collects coarse-grained command usage data (command name, exit code, duration) to inform feature priority. The CLI never collects model content, paths, or query text. |
 
 ```bash
@@ -248,6 +250,7 @@ Use the following CLI-specific environment variables for paths, behavior, and di
 | `NO_SPINNER` | Set to `1` or `true` to disable animated progress indicators (alternative to `spinner: false` in config). |
 | `CI` | Auto-detected. When `1` or `true`, the CLI disables the spinner and switches to plain output. Most CI runners set this automatically. |
 | `TE_SESSION` | Override the per-terminal session ID used for active-connection state. Useful for running multiple isolated CLI sessions inside the same shell, e.g. in parallel CI matrix jobs. Inspect and manage sessions with [`te session`](xref:te-cli-commands#session). |
+| `TE_INTERACTIVE` | Override `launchInteractiveMode` for a single invocation. Accepts `auto`, `always`, or `never`. Handy for one-off scripts that want the interactive REPL (`TE_INTERACTIVE=always`) or want to force the classic help-on-empty behavior (`TE_INTERACTIVE=never`) without touching the config file. |
 | `TE_COMPAT` | Set to `te2` to force TE2-compatibility mode - see @te-cli-migrate. |
 
 ## Related pages

--- a/content/features/te-cli/te-cli-interactive.md
+++ b/content/features/te-cli/te-cli-interactive.md
@@ -149,6 +149,27 @@ Two separate messages can appear at the start of a session - don't conflate them
 - The **welcome banner** is the interactive splash described under [Starting a session](#starting-a-session). It is suppressed with `--no-banner`. When stdin is piped, no welcome banner is emitted in the first place, so `--no-banner` has a visible effect only in a true interactive (TTY) session.
 - The **preview-expiry notice** (`This is an early preview release ...`) is a different message. It is always written to **stderr** and is **not** affected by `--no-banner`. Suppress it with `te config set hidePreviewNotice true`.
 
+## Auto-launch on empty invocation
+
+Running `te` in a terminal with no arguments drops you straight into the interactive REPL, so exploring a model is as fast as opening a shell and typing `te`. When stdin, stdout, or stderr is redirected (piped output, CI pipelines, scripts), the CLI falls through to its normal parse and prints help instead - so shell scripts that invoke `te` without a subcommand keep behaving the same way.
+
+The behavior is controlled by the `launchInteractiveMode` config key with three values:
+
+| Value | Effect |
+| -- | -- |
+| `auto` (default) | Launch the REPL only when all three streams are attached to a TTY. Otherwise fall through to normal parse. |
+| `always` | Launch the REPL regardless of stream redirection. Useful when you always want an interactive session. |
+| `never` | Never auto-launch the REPL. `te` on its own prints help, matching the pre-0.6.0 behavior. |
+
+Change it globally with:
+
+```bash
+te config set launchInteractiveMode never    # keep the classic help-on-empty behavior
+te config set launchInteractiveMode auto     # restore the default
+```
+
+Override for a single invocation via the `TE_INTERACTIVE` environment variable (same values), or pass `--non-interactive` on the command line - both force `never` for that call, so `te --non-interactive` prints help instead of launching the REPL.
+
 ## When to use interactive vs. non-interactive
 
 - **Interactive mode** is best for exploration, learning the CLI, one-off bulk edits against a single model, and demos.

--- a/content/features/te-cli/te-cli.md
+++ b/content/features/te-cli/te-cli.md
@@ -58,6 +58,9 @@ See @te-cli-commands for a full command reference with syntax, options, and exam
 | [Configuration](xref:te-cli-commands#configuration) | Settings and licensing | [`te config`](xref:te-cli-commands#config-list--paths--init--set) |
 | [Shell](xref:te-cli-commands#shell) | Interactive mode, session state, shell completions | [`te interactive`](xref:te-cli-commands#interactive), [`te session`](xref:te-cli-commands#session), [`te completion`](xref:te-cli-commands#completion) |
 
+> [!TIP]
+> The docs use canonical long-form verbs (`list`, `remove`, `move`), but the classic short forms still work as aliases (`ls`, `rm`, `mv`, `rename`). This applies to top-level commands and to `remove` / `list` subcommands under groups like `te bpa rules`, `te macro`, `te config`, `te profile`, `te session`, and `te test`. See @te-cli-commands#command-aliases for the full mapping.
+
 ## Getting started
 
 1. **Sign up or sign in** at [tabulareditor.com](https://tabulareditor.com/download-tabular-editor-cli) with a Tabular Editor account.

--- a/content/features/te-cli/te-cli.md
+++ b/content/features/te-cli/te-cli.md
@@ -66,7 +66,7 @@ See @te-cli-commands for a full command reference with syntax, options, and exam
 1. **Sign up or sign in** at [tabulareditor.com](https://tabulareditor.com/download-tabular-editor-cli) with a Tabular Editor account.
 2. **Download and install** - see @te-cli-install for Windows, macOS, and Linux instructions.
 3. **Authenticate** - run `te auth login` to connect to Power BI or Fabric. See @te-cli-auth.
-4. **Run your first command** - `te --help` lists every command; `te <command> --help` shows detailed options.
+4. **Run your first command** - `te --help` lists every command; `te <command> --help` shows detailed options. Tip: running `te` on its own in a terminal drops you into the interactive REPL - a friendly way to explore a model. See @te-cli-interactive.
 
 A first look at a live model takes two commands:
 


### PR DESCRIPTION
## Summary

Fills two gaps in the CLI docs left over from the 0.6.0 milestone: **command aliases** were only documented for the three top-level renames, and the **new `launchInteractiveMode` config key + `TE_INTERACTIVE` env var** (running `te` in a terminal drops you into the REPL) were completely undocumented.

## Command aliases

- New **Command aliases** reference table on `te-cli-commands.md` listing every canonical/aliased pair (13 in total). Aliases shown as full aliased commands (`te incremental-refresh rm`, not bare `rm`) to remove any ambiguity about scope.
- Inline `(alias X)` annotations on every subcommand overview table row where an alias exists (`bpa rules`, `macro`, `config`, `session`, `profile`, `test`, `incremental-refresh`).
- First-line alias mention on H4 subcommand headings that have one.
- One-time TIP callout on `te-cli.md` (overview) pointing new users to the full aliases table.

## Interactive-mode auto-launch

Documenting the new default behavior where running `te` in a terminal with no arguments drops you into the REPL, plus the `launchInteractiveMode` config key (`auto` / `always` / `never`) and the `TE_INTERACTIVE` env var that control it.

- `te-cli-config.md` - schema example, Behavioral defaults table, and env variables table.
- `te-cli-interactive.md` - new "Auto-launch on empty invocation" section.
- `te-cli-commands.md` - TIP under `### interactive`.
- `te-cli.md` - one-liner in the "Getting started" section.

## Deliberate omission

`te config show` was removed in 0.6.0 (unlike the other renames, `show` is not kept as an alias). This is documented in the 0.6.0 announcement as a breaking change but **not** added as a "removed" note on the docs pages themselves, to avoid the docs accumulating a graveyard of removed-command notes.

## Files changed

- `content/features/te-cli/te-cli.md`
- `content/features/te-cli/te-cli-commands.md`
- `content/features/te-cli/te-cli-config.md`
- `content/features/te-cli/te-cli-interactive.md`
