### PR TITLE
docs: add compatibility level 1705

### DIFF
--- a/content/features/te-cli/te-cli-commands.md
+++ b/content/features/te-cli/te-cli-commands.md
@@ -215,19 +215,19 @@ te open ./model.bim      # Open a BIM file in TE3
 
 ### init
 
-Create a new empty semantic model at the given path. Defaults to a TMDL model in `PowerBI` compatibility mode at compatibility level 1702.
+Create a new empty semantic model at the given path. Defaults to a TMDL model in `PowerBI` compatibility mode at compatibility level 1705.
 
 `te init` accepts:
 
 - `<output-path>` - positional argument: directory to create the model in (omit to use the global `--model` path).
 - `--compatibility-mode <mode>` - `PowerBI` (default) or `AnalysisServices`.
-- `--compatibility-level <N>` (alias `--compat`) - compatibility level. Defaults to `1702` when the mode is `PowerBI`, `1500` otherwise. See @update-compatibility-level.
+- `--compatibility-level <N>` (alias `--compat`) - compatibility level. Defaults to `1705` when the mode is `PowerBI`, `1500` otherwise. See @update-compatibility-level.
 - `--name <name>` - model/database name (default: the directory name).
 - `--serialization <fmt>` - `tmdl` (default), `bim` (alias `tmsl`), `database.json`, `pbip`.
 - `--force` - replace any existing file or directory at the target path.
 
 ```bash
-te init ./new-model                                       # TMDL, PowerBI mode, compat 1702
+te init ./new-model                                       # TMDL, PowerBI mode, compat 1705
 te init ./new-model --serialization bim                   # Single-file BIM model
 te init ./as-model --compatibility-mode AnalysisServices  # AS model, compat 1500
 te init ./existing-dir --force                            # Overwrite non-empty directory

--- a/content/how-tos/update-compatibility-level.md
+++ b/content/how-tos/update-compatibility-level.md
@@ -30,7 +30,7 @@ Compatibility Level and Compatibility Mode are separate properties that serve di
 
 | Property | Controls | Values |
 |---|---|---|
-| `Database.CompatibilityLevel` | Which TOM features are available (e.g., custom calendars, DAX UDFs) | `1200`, `1500`, `1600`, `1701`, `1702`, etc. |
+| `Database.CompatibilityLevel` | Which TOM features are available (e.g., custom calendars, DAX UDFs) | `1200`, `1500`, `1600`, `1701`, `1702`, `1705`, etc. |
 | `Database.CompatibilityMode` | Which platform the model targets, which TOM objects and properties are available, and which edition restrictions apply | `Unknown`, `AnalysisServices`, `PowerBI`, `Excel` |
 
 If you need to change the platform target rather than unlock new TOM features, see [Change compatibility mode](xref:change-compatibility-mode).
@@ -40,7 +40,7 @@ If you need to change the platform target rather than unlock new TOM features, s
 Upgrade when:
 
 - A feature exists in Power BI Desktop but the related TOM property is missing in Tabular Editor
-- You need newly introduced capabilities like **custom calendars** (1701+) or **DAX user-defined functions** (1702+)
+- You need newly introduced capabilities like **custom calendars** (1701+), **DAX user-defined functions** (1702+), or **user-context calculated columns** (calculated columns that use user-context functions, 1705+)
 - You're standardizing development across environments and want consistent minimum feature sets
 
 ## Before you start
@@ -86,6 +86,7 @@ Examples:
 
 - **Custom calendars:** 1701+
 - **DAX UDFs:** 1702+
+- **User-context calculated columns:** 1705+
 
 > [!NOTE]
 > Minimum required levels for features can change as the platform evolves. Always verify prerequisites in current documentation. Some levels/features are Power BI-only and may not be available on SSAS/AAS.

--- a/content/kb/bpa-powerbi-latest-compatibility.md
+++ b/content/kb/bpa-powerbi-latest-compatibility.md
@@ -70,13 +70,13 @@ Team policy to delay upgrades.
 
 ```
 Model Compatibility Level: 1500
-Current Maximum Level: 1700
+Current Maximum Level: 1705
 ```
 
 ### After Fix
 
 ```
-Model Compatibility Level: 1700 (Latest)
+Model Compatibility Level: 1705 (Latest)
 ```
 
 Access to new features like enhanced calculation groups and field parameters.

--- a/content/tutorials/new-pbi-model.md
+++ b/content/tutorials/new-pbi-model.md
@@ -34,7 +34,7 @@ This page walks you through the process of creating a new Power BI semantic mode
 
 ![New model](~/content/assets/images/tutorials/new-pbi-model.png)
 
-- Provide a name for your model or use the default value. Then, set the compatibility level to "1705 (Power BI / Fabric)" (the latest Power BI / Fabric level). "1702 (Power BI / Fabric)" also remains available if you need it.
+- Provide a name for your model or use the default value. Then, set the compatibility level to "1705 (Power BI / Fabric)" (the latest Power BI / Fabric level).
 - For the best development experience, check the "Use workspace database" option. This requires that you have a development workspace available in Power BI, with XMLA read/write enabled. When you click OK, you will be prompted to enter the connection string for the Power BI workspace in which you want the workspace database created.
 
 > [!NOTE]

--- a/content/tutorials/new-pbi-model.md
+++ b/content/tutorials/new-pbi-model.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: new-pbi-model
 title: Create a Power BI Semantic Model
 author: Daniel Otykier
@@ -34,7 +34,7 @@ This page walks you through the process of creating a new Power BI semantic mode
 
 ![New model](~/content/assets/images/tutorials/new-pbi-model.png)
 
-- Provide a name for your model or use the default value. Then, set the compatibility level to "1609 (Power BI / Fabric)".
+- Provide a name for your model or use the default value. Then, set the compatibility level to "1705 (Power BI / Fabric)" (the latest Power BI / Fabric level). "1702 (Power BI / Fabric)" also remains available if you need it.
 - For the best development experience, check the "Use workspace database" option. This requires that you have a development workspace available in Power BI, with XMLA read/write enabled. When you click OK, you will be prompted to enter the connection string for the Power BI workspace in which you want the workspace database created.
 
 > [!NOTE]


### PR DESCRIPTION
## Summary

Documents Tabular Editor support for TOM compatibility level **1705** (Power BI / Fabric), the new latest level. 1702 remains available.

Changes:
- **Update compatibility level** how-to (`content/how-tos/update-compatibility-level.md`): add 1705 to the level list and a "user-context calculated columns (1705+)" capability entry.
- **New Model (Power BI)** tutorial (`content/tutorials/new-pbi-model.md`): point to "1705 (Power BI / Fabric)" as the latest level, noting 1702 is still available. Also corrects a stale "1609" value.
- **te CLI** reference (`content/features/te-cli/te-cli-commands.md`): `te init` now defaults to 1705 for PowerBI mode.
- **BPA KB** page (`content/kb/bpa-powerbi-latest-compatibility.md`): update the example's current-maximum-level to 1705.

The New Model dialog's Analysis Services tutorial is unchanged, since 1705 is a Power BI / Fabric level, not an SSAS/AAS level.

## Notes

- English source only; localized `es`/`zh` copies are handled via Crowdin.
- This reflects TE3 code support for 1705 that is landing in an upcoming release.
