### PR TITLE
docs(cli): correct inverted --long description for te format

### DIFF
--- a/content/features/te-cli/te-cli-commands.md
+++ b/content/features/te-cli/te-cli-commands.md
@@ -691,7 +691,7 @@ Format DAX or M/Power Query expressions.
 - `-t, --type <kind>` - disambiguate when the path matches multiple table-children.
 - `--lang <lang>` - expression language: `dax` (default) or `m`/`pq` for Power Query.
 - `--semicolons` - use semicolons as list separators (European locale).
-- `--long` - use long format (more line breaks). Default is short.
+- `--long` - use long format (fewer line breaks). Default is short.
 - `--no-space-after-function` - skip the space after function names.
 - `--save` / `--save-to` - persist formatted expressions.
 


### PR DESCRIPTION
`--long` produces fewer line breaks, not more — it selects the larger line budget
(for the CLI, 120 chars vs 60). The current text describes what short format does;
the CLI help string is being fixed in parallel.

The `es` and `zh` copies under `localizedContent/` carry the same error. Editing the
source line re-opens the string in Crowdin for re-translation, so they are left alone
here rather than hand-edited.
