### PR TITLE
docs(cli): correct the relationship path form and note the TOM name

### DIFF
--- a/content/features/te-cli/te-cli-commands.md
+++ b/content/features/te-cli/te-cli-commands.md
@@ -87,7 +87,9 @@ Several names act as container keywords. A keyword can stand alone (listing the 
 | `Levels` | Hierarchy | Levels of a hierarchy. |
 | `Members`, `TablePermissions` (alias `Permissions`) | Role | Children of a role. |
 
-Calculated sets are addressable in container form only (`<table>/Sets/<name>`); an individual KPI is `<table>/<measure>/KPI`; calendars resolve at `<table>/Calendars/<name>`; relationships resolve at `Relationships/{guid}` (`--paths-only` prints the GUID form, and the display name is also accepted).
+Calculated sets are addressable in container form only (`<table>/Sets/<name>`); an individual KPI is `<table>/<measure>/KPI`; calendars resolve at `<table>/Calendars/<name>`; relationships resolve at `Relationships/"{guid}"`.
+
+`--paths-only` prints the relationship's TOM name, which is not always a GUID: it is the GUID in Power BI models, and a display-style name such as `Relationships/Relationship 1` in SSAS-sourced models. Because `{` and `}` are reserved characters in a path, a name containing them has to be quoted - `Relationships/"{guid}"` - and `--paths-only` prints it that way, ready to paste into another command. The display name is also accepted.
 
 A few examples show how plain and container-scoped paths differ:
 


### PR DESCRIPTION
Closes work item **7269**.

Targets `user-pg/cli-0.7.0` (the branch behind #386), not `main` - these are 0.7.0 docs and must not go live before the CLI ships.

## The problem

The **Containers and keywords** section documented relationship paths as `Relationships/{guid}`. As of 0.7.0, `{` and `}` are reserved characters in CLI object and filter paths (`[Breaking] Braces asterisks and question marks in object names must be quoted in paths`), so that form is refused by the path parser rather than resolved:

```
te get "Relationships/{2c4f8a19-1c2d-4e3f-9a8b-7c6d5e4f3a2b}"
Error: '{' at position 14 is reserved for future brace expansion.
       Quote the segment to use it literally: '{foo}' or "{foo}".
exit 1
```

The single-quoted form is refused too, because a single-quoted segment must reference a table. Double quotes and brackets both resolve.

Two rules in the same release contradicted each other.

## The change

One paragraph in `content/features/te-cli/te-cli-commands.md`:

- `Relationships/{guid}` -> `Relationships/"{guid}"`
- Adds a note that `--paths-only` prints the relationship's **TOM name**, which is not always a GUID: the GUID in Power BI models, a display-style name such as `Relationships/Relationship 1` in SSAS-sourced models.
- Explains why the quoting is there, so the path form and the reserved-character rule no longer read as contradictory.



