### PR TITLE
docs(cli): correct the relationship path form and drop the GUID claim

### DIFF
--- a/content/features/te-cli/te-cli-commands.md
+++ b/content/features/te-cli/te-cli-commands.md
@@ -87,7 +87,7 @@ Several names act as container keywords. A keyword can stand alone (listing the 
 | `Levels` | Hierarchy | Levels of a hierarchy. |
 | `Members`, `TablePermissions` (alias `Permissions`) | Role | Children of a role. |
 
-Calculated sets are addressable in container form only (`<table>/Sets/<name>`); an individual KPI is `<table>/<measure>/KPI`; calendars resolve at `<table>/Calendars/<name>`; relationships resolve at `Relationships/{guid}` (`--paths-only` prints the GUID form, and the display name is also accepted).
+Calculated sets are addressable in container form only (`<table>/Sets/<name>`); an individual KPI is `<table>/<measure>/KPI`; calendars resolve at `<table>/Calendars/<name>`; relationships resolve at `Relationships/<name>` (the relationship's own name in the model: a GUID, or a label such as `Relationship 1`; `--paths-only` prints it, and the display name is also accepted).
 
 A few examples show how plain and container-scoped paths differ:
 


### PR DESCRIPTION
Closes work item **7269**. Replaces #391 (closed).

Targets `user-pg/cli-0.7.0`, the branch behind #386, so this does not reach `main` before the CLI 0.7.0 ships.

One line in `content/features/te-cli/te-cli-commands.md`, in **Containers and keywords**:

```diff
-relationships resolve at `Relationships/{guid}` (`--paths-only` prints the GUID form, and the display name is also accepted).
+relationships resolve at `Relationships/<name>` (the relationship's own name in the model: a GUID, or a label such as `Relationship 1`; `--paths-only` prints it, and the display name is also accepted).
```

## Two defects, both fixed by that line

**1. The documented path was unparseable.** `{` and `}` became reserved characters in 0.7.0 (`[Breaking] Braces asterisks and question marks in object names must be quoted in paths`), so the documented form is refused rather than resolved:

```
te get "Relationships/{2c4f8a19-1c2d-4e3f-9a8b-7c6d5e4f3a2b}"
Error: '{' at position 14 is reserved for future brace expansion.
exit 1
```

Two rules in the same release contradicted each other. `<name>` matches the placeholder convention used everywhere else in that sentence and collides with nothing.

**2. It promised a GUID.** The name is whatever the model carries. Census of every checked-in `.bim` fixture, deduplicated by content hash, **52 distinct models / 3493 relationships**:

| Name shape | Count | Share |
| -- | -- | -- |
| `Relationship N` | 1906 | 54.6% |
| bare GUID | 1579 | 45.2% |
| `New Single Column Relationship N` | 5 | 0.1% |
| hand-authored | 3 | 0.1% |
| braced GUID | 0 | 0% |

The shapes are also not split by source: `AdventureWorks.bim` and three other fixtures mix GUID and `Relationship N` inside one model, and `TOMWrapperTest/TestData/TMDL-SSAS-Model/relationships.tmdl`, an SSAS-sourced model, is entirely bare GUIDs.

Verified against te 0.7.0.3, one model per shape. All three round-trip into `te get` unchanged:

| TOM name | `--paths-only` prints |
| -- | -- |
| `6f6e1b0a-1c2d-4e3f-9a8b-7c6d5e4f3a2b` | `Relationships/6f6e1b0a-1c2d-4e3f-9a8b-7c6d5e4f3a2b` |
| `{2c4f8a19-1c2d-4e3f-9a8b-7c6d5e4f3a2b}` | `Relationships/"{2c4f8a19-1c2d-4e3f-9a8b-7c6d5e4f3a2b}"` |
| `Relationship 1` | `Relationships/Relationship 1` |

Quoting tracks whether the name contains a reserved character, not the object type, so it belongs in the **Quoting** section (line 51) that already owns that rule rather than in this clause.

## Follow-ups, deliberately not in this PR

1. `Relationships/{guid}` also appears three times in the TE3 repo release notes on `release/tecli/0.7.0`. Separate repo, separate PR.
2. Line 63 of this page says the mixed-quote forms "require PowerShell or bash; cmd.exe cannot express them." Windows PowerShell cannot express them either: `'Relationships/"{guid}"'` works only on PowerShell 7.3+ with `Standard` native argument passing, and fails under `Legacy`. The bracket form `"Relationships/[{guid}]"` works in every shell tested.
3. CLI defects, not docs: the brace error suggests `'{foo}'` first, which can never work in a non-table container; and `te add` silently created a second active relationship on an endpoint pair that already had one, giving two indistinguishable rows in `te list`.
<img width="486" height="52" alt="image" src="https://github.com/user-attachments/assets/b820a94a-5ae8-4101-9adf-449a54b1a513" />

